### PR TITLE
Offer backup before swapping ports

### DIFF
--- a/custom_components/ha_rbac/config_flow.py
+++ b/custom_components/ha_rbac/config_flow.py
@@ -115,7 +115,7 @@ class RbacConfigFlow(ConfigFlow, domain=DOMAIN):
                 errors[CONF_PROXY_PORT] = "port_conflict"
             else:
                 self._data = data
-                return await self.async_step_move()
+                return await self.async_step_backup()
 
         return self.async_show_form(
             step_id="user",
@@ -165,6 +165,35 @@ class RbacConfigFlow(ConfigFlow, domain=DOMAIN):
             "directly with the token they already have."
         )
 
+    async def async_step_backup(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Offer to create a backup before changing ports.
+
+        The next step restarts Home Assistant on a different port. A backup
+        gives the user a way back if something unexpected happens -- the
+        five-minute revert restores the port and bind address, but not the
+        integration's own configuration or anything outside the HTTP server.
+        The backup runs in the background and does not block the flow.
+        """
+        return self.async_show_menu(
+            step_id="backup",
+            menu_options=["backup_create", "backup_skip"],
+        )
+
+    async def async_step_backup_create(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Fire a backup and continue to the move step."""
+        await self.hass.services.async_call("backup", "create", blocking=False)
+        return await self.async_step_move()
+
+    async def async_step_backup_skip(
+        self, user_input: dict[str, Any] | None = None
+    ) -> ConfigFlowResult:
+        """Skip the backup and continue to the move step."""
+        return await self.async_step_move()
+
     async def async_step_move(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
@@ -210,6 +239,9 @@ class RbacConfigFlow(ConfigFlow, domain=DOMAIN):
 
 class RbacOptionsFlow(OptionsFlow):
     """Handle reconfiguration."""
+
+    # TODO: offer a backup step here too, at least when `manage_http` is being
+    # toggled on for the first time -- the same port-swap risk applies.
 
     async def async_step_init(
         self, user_input: dict[str, Any] | None = None

--- a/custom_components/ha_rbac/strings.json
+++ b/custom_components/ha_rbac/strings.json
@@ -17,6 +17,14 @@
           "upstream_port": "Where Home Assistant will answer instead. Nothing you use needs to know about this port."
         }
       },
+      "backup": {
+        "title": "Create a backup first?",
+        "description": "The next step can restart Home Assistant on a different port. If something goes wrong, Home Assistant reverts by itself within five minutes — but a backup gives you a second way back.\n\nThe backup runs in the background and does not slow anything down.",
+        "menu_options": {
+          "backup_create": "Create a backup, then continue",
+          "backup_skip": "Skip, continue without a backup"
+        }
+      },
       "move": {
         "title": "Move Home Assistant out of the way",
         "description": "Roles are only enforced on traffic that comes through here, so Home Assistant has to stop answering on the network itself. Otherwise anyone can go straight round this with the token they already have.\n\nHome Assistant can be moved to port {upstream_port}, reachable only from its own machine, leaving port {proxy_port} to this. It restarts once and comes back on {proxy_port} in about fifteen seconds.\n\nIf it does not come back, Home Assistant undoes the change within five minutes and restarts again on {proxy_port} as it is now.",

--- a/custom_components/ha_rbac/translations/en.json
+++ b/custom_components/ha_rbac/translations/en.json
@@ -17,6 +17,14 @@
           "upstream_port": "Where Home Assistant will answer instead. Nothing you use needs to know about this port."
         }
       },
+      "backup": {
+        "title": "Create a backup first?",
+        "description": "The next step can restart Home Assistant on a different port. If something goes wrong, Home Assistant reverts by itself within five minutes — but a backup gives you a second way back.\n\nThe backup runs in the background and does not slow anything down.",
+        "menu_options": {
+          "backup_create": "Create a backup, then continue",
+          "backup_skip": "Skip, continue without a backup"
+        }
+      },
       "move": {
         "title": "Move Home Assistant out of the way",
         "description": "Roles are only enforced on traffic that comes through here, so Home Assistant has to stop answering on the network itself. Otherwise anyone can go straight round this with the token they already have.\n\nHome Assistant can be moved to port {upstream_port}, reachable only from its own machine, leaving port {proxy_port} to this. It restarts once and comes back on {proxy_port} in about fifteen seconds.\n\nIf it does not come back, Home Assistant undoes the change within five minutes and restarts again on {proxy_port} as it is now.",

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -49,6 +49,10 @@ async def test_the_wizard_offers_to_move_home_assistant(
 ) -> None:
     """The step that exists so nobody has to know the install order."""
     step = await flow.async_step_user(PORTS)
+    assert step["type"] is FlowResultType.MENU
+    assert step["step_id"] == "backup"
+
+    step = await flow.async_step_backup_skip()
     assert step["type"] is FlowResultType.FORM
     assert step["step_id"] == "move"
     assert step["description_placeholders"] == {
@@ -65,6 +69,7 @@ async def test_the_wizard_offers_to_move_home_assistant(
 async def test_declining_the_move_still_sets_up(flow: RbacConfigFlow) -> None:
     """Doing it by hand stays a supported route, not a dead end."""
     await flow.async_step_user(PORTS)
+    await flow.async_step_backup_skip()
     step = await flow.async_step_move({CONF_MANAGE_HTTP: False})
     assert step["type"] is FlowResultType.CREATE_ENTRY
     assert step["data"][CONF_MANAGE_HTTP] is False
@@ -79,10 +84,14 @@ async def test_the_move_is_not_offered_where_it_cannot_be_done(
     manual route, and the wizard should not stop to ask about something it
     would then fail to do.
     """
+    step = await flow.async_step_user(PORTS)
+    assert step["type"] is FlowResultType.MENU
+    assert step["step_id"] == "backup"
+
     with patch(
         "custom_components.ha_rbac.http_config.async_can_manage", return_value=False
     ):
-        step = await flow.async_step_user(PORTS)
+        step = await flow.async_step_backup_skip()
 
     assert step["type"] is FlowResultType.CREATE_ENTRY
     assert step["data"][CONF_MANAGE_HTTP] is False
@@ -150,6 +159,21 @@ async def test_no_manual_instruction_when_the_move_is_on_offer(
     with patch.object(hass.http, "server_host", ["0.0.0.0"], create=True):
         step = await flow.async_step_user()
     assert step["description_placeholders"] == {"warning": ""}
+
+
+async def test_the_backup_step_fires_backup_create(
+    hass: HomeAssistant, flow: RbacConfigFlow
+) -> None:
+    """Choosing "create a backup" calls the service, then moves on."""
+    await flow.async_step_user(PORTS)
+
+    with patch.object(hass.services, "async_call") as mock_call:
+        step = await flow.async_step_backup_create()
+
+    mock_call.assert_called_once_with("backup", "create", blocking=False)
+    # It should land on the move step.
+    assert step["type"] is FlowResultType.FORM
+    assert step["step_id"] == "move"
 
 
 async def test_the_manual_instruction_survives_where_it_is_the_only_route(


### PR DESCRIPTION
The setup flow now shows a menu between port config and the move step, letting the user create a background backup before Home Assistant restarts on a different port. Optional and non-blocking — skipping continues straight to the move.