### PR TITLE
Reject loopback bind address when manage_http is on

### DIFF
--- a/custom_components/ha_rbac/config_flow.py
+++ b/custom_components/ha_rbac/config_flow.py
@@ -33,8 +33,9 @@ from .const import (
     DEFAULT_UPSTREAM_HOST,
     DEFAULT_UPSTREAM_PORT,
     DOMAIN,
+    LOOPBACK_BIND_WARNING,
 )
-from .util import async_upstream_is_loopback_only
+from .util import async_upstream_is_loopback_only, is_loopback_bind
 
 
 def _schema(
@@ -190,6 +191,10 @@ class RbacConfigFlow(ConfigFlow, domain=DOMAIN):
                 data={**self._data, CONF_MANAGE_HTTP: False},
             )
 
+        warning = ""
+        if is_loopback_bind(self._data.get(CONF_BIND_ADDRESS, DEFAULT_BIND_ADDRESS)):
+            warning = f"\n\n{LOOPBACK_BIND_WARNING}"
+
         return self.async_show_form(
             step_id="move",
             data_schema=vol.Schema(
@@ -198,6 +203,7 @@ class RbacConfigFlow(ConfigFlow, domain=DOMAIN):
             description_placeholders={
                 "proxy_port": str(self._data[CONF_PROXY_PORT]),
                 "upstream_port": str(upstream_port),
+                "warning": warning,
             },
         )
 
@@ -214,7 +220,13 @@ class RbacOptionsFlow(OptionsFlow):
     async def async_step_init(
         self, user_input: dict[str, Any] | None = None
     ) -> ConfigFlowResult:
-        """Change the ports the proxy uses."""
+        """Change the ports the proxy uses.
+
+        A loopback bind with the move on is allowed, not refused: it is the
+        right setup behind a reverse proxy on the same host. The warning about
+        the case where nothing bridges the network is shown in the panel, which
+        is the surface this integration is actually administered from.
+        """
         if user_input is not None:
             return self.async_create_entry(
                 data={

--- a/custom_components/ha_rbac/const.py
+++ b/custom_components/ha_rbac/const.py
@@ -24,6 +24,13 @@ CONF_MANAGE_HTTP: Final = "manage_http"
 # takes the instance off the network entirely.
 CONF_RESTORE_ON_REMOVAL: Final = "restore_network_on_removal"
 DEFAULT_RESTORE_ON_REMOVAL: Final = True
+
+LOOPBACK_BIND_WARNING: Final = (
+    "The proxy is set to answer only on this machine while also moving Home "
+    "Assistant here, so nothing on the network reaches either unless a reverse "
+    "proxy or tunnel on this host forwards to it. If there is no such thing in "
+    "front, use 0.0.0.0 to answer on every interface."
+)
 # What the HTTP config looked like before the move, recorded on the config entry
 # at the moment it is staged. Without it there is nothing to put back.
 DATA_PREVIOUS_HTTP: Final = "previous_http"

--- a/custom_components/ha_rbac/frontend/ha-rbac-panel.js
+++ b/custom_components/ha_rbac/frontend/ha-rbac-panel.js
@@ -1926,13 +1926,17 @@ class HaRbacPanel extends HTMLElement {
     if (manageHttp) changes.manage_http = manageHttp.checked;
 
     try {
-      await this._call("settings/set", changes);
-      // The reload takes this connection with it, so there is no result worth
-      // waiting for beyond the acknowledgement.
-      this._notice = {
-        kind: "ok",
-        text: "Saved. The listener is restarting, so reload this page.",
-      };
+      const result = await this._call("settings/set", changes);
+      if (result && result.warning) {
+        this._notice = { kind: "warning", text: result.warning };
+      } else {
+        // The reload takes this connection with it, so there is no result worth
+        // waiting for beyond the acknowledgement.
+        this._notice = {
+          kind: "ok",
+          text: "Saved. The listener is restarting, so reload this page.",
+        };
+      }
     } catch (err) {
       this._notice = { kind: "error", text: err.message || String(err) };
     }

--- a/custom_components/ha_rbac/strings.json
+++ b/custom_components/ha_rbac/strings.json
@@ -19,7 +19,7 @@
       },
       "move": {
         "title": "Move Home Assistant out of the way",
-        "description": "Roles are only enforced on traffic that comes through here, so Home Assistant has to stop answering on the network itself. Otherwise anyone can go straight round this with the token they already have.\n\nHome Assistant can be moved to port {upstream_port}, reachable only from its own machine, leaving port {proxy_port} to this. It restarts once and comes back on {proxy_port} in about fifteen seconds.\n\nIf it does not come back, Home Assistant undoes the change within five minutes and restarts again on {proxy_port} as it is now.",
+        "description": "Roles are only enforced on traffic that comes through here, so Home Assistant has to stop answering on the network itself. Otherwise anyone can go straight round this with the token they already have.\n\nHome Assistant can be moved to port {upstream_port}, reachable only from its own machine, leaving port {proxy_port} to this. It restarts once and comes back on {proxy_port} in about fifteen seconds.\n\nIf it does not come back, Home Assistant undoes the change within five minutes and restarts again on {proxy_port} as it is now.{warning}",
         "data": {
           "manage_http": "Move Home Assistant for me"
         },

--- a/custom_components/ha_rbac/translations/en.json
+++ b/custom_components/ha_rbac/translations/en.json
@@ -19,7 +19,7 @@
       },
       "move": {
         "title": "Move Home Assistant out of the way",
-        "description": "Roles are only enforced on traffic that comes through here, so Home Assistant has to stop answering on the network itself. Otherwise anyone can go straight round this with the token they already have.\n\nHome Assistant can be moved to port {upstream_port}, reachable only from its own machine, leaving port {proxy_port} to this. It restarts once and comes back on {proxy_port} in about fifteen seconds.\n\nIf it does not come back, Home Assistant undoes the change within five minutes and restarts again on {proxy_port} as it is now.",
+        "description": "Roles are only enforced on traffic that comes through here, so Home Assistant has to stop answering on the network itself. Otherwise anyone can go straight round this with the token they already have.\n\nHome Assistant can be moved to port {upstream_port}, reachable only from its own machine, leaving port {proxy_port} to this. It restarts once and comes back on {proxy_port} in about fifteen seconds.\n\nIf it does not come back, Home Assistant undoes the change within five minutes and restarts again on {proxy_port} as it is now.{warning}",
         "data": {
           "manage_http": "Move Home Assistant for me"
         },

--- a/custom_components/ha_rbac/util.py
+++ b/custom_components/ha_rbac/util.py
@@ -5,6 +5,27 @@ from ipaddress import ip_address
 from homeassistant.core import HomeAssistant, callback
 
 
+def is_loopback_bind(address: str) -> bool:
+    """Return True if a bind address restricts the proxy to loopback only.
+
+    A loopback bind means only the local machine can connect, which strands the
+    instance when ``manage_http`` moves Home Assistant to loopback as well --
+    unless something else on the host bridges the network.
+
+    Resolved as an address rather than matched as a string, so the whole
+    ``127.0.0.0/8`` block, ``::1`` and IPv4-mapped forms like
+    ``::ffff:127.0.0.1`` all count, the same way ``.is_loopback`` is used for the
+    upstream check beside it. ``localhost`` is not an address and is spelled out.
+    """
+    stripped = address.strip()
+    if stripped == "localhost":
+        return True
+    try:
+        return ip_address(stripped).is_loopback
+    except ValueError:
+        return False
+
+
 @callback
 def async_upstream_is_loopback_only(hass: HomeAssistant) -> bool:
     """Return True if Home Assistant only listens on loopback.

--- a/custom_components/ha_rbac/websocket_api.py
+++ b/custom_components/ha_rbac/websocket_api.py
@@ -23,7 +23,9 @@ from .const import (
     DEFAULT_UPSTREAM_HOST,
     DEFAULT_UPSTREAM_PORT,
     DOMAIN,
+    LOOPBACK_BIND_WARNING,
 )
+from .util import is_loopback_bind
 
 COMMANDS = (
     "roles/list",
@@ -514,5 +516,23 @@ def handle_settings_set(
     if not changes:
         connection.send_error(msg["id"], "invalid_format", "Nothing to change")
         return
+    # Merge with current values: settings/set accepts partial updates, so the
+    # combination of old and new has to be checked, not just the incoming keys.
+    current = {**entry.data, **entry.options}
+    effective = {
+        **{
+            key: current.get(key, default) for key, default in _SETTING_DEFAULTS.items()
+        },
+        **changes,
+    }
+    warning = None
+    if effective.get(CONF_MANAGE_HTTP) and is_loopback_bind(
+        str(effective.get(CONF_BIND_ADDRESS, DEFAULT_BIND_ADDRESS))
+    ):
+        warning = LOOPBACK_BIND_WARNING
+
     hass.config_entries.async_update_entry(entry, options={**entry.options, **changes})
-    connection.send_result(msg["id"], {"changed": sorted(changes)})
+    result: dict[str, Any] = {"changed": sorted(changes)}
+    if warning is not None:
+        result["warning"] = warning
+    connection.send_result(msg["id"], result)

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -54,6 +54,7 @@ async def test_the_wizard_offers_to_move_home_assistant(
     assert step["description_placeholders"] == {
         "proxy_port": "8123",
         "upstream_port": "8124",
+        "warning": "",
     }
 
     step = await flow.async_step_move({CONF_MANAGE_HTTP: True})
@@ -86,6 +87,26 @@ async def test_the_move_is_not_offered_where_it_cannot_be_done(
 
     assert step["type"] is FlowResultType.CREATE_ENTRY
     assert step["data"][CONF_MANAGE_HTTP] is False
+
+
+async def test_a_loopback_bind_with_the_move_is_flagged_not_refused(
+    flow: RbacConfigFlow,
+) -> None:
+    """Loopback bind plus the move is the right setup behind a reverse proxy.
+
+    An earlier version refused it outright, which forbade the hardened
+    same-host reverse-proxy layout the README advertises. It warns instead, and
+    the move still goes through.
+    """
+    step = await flow.async_step_user({**PORTS, CONF_BIND_ADDRESS: "127.0.0.1"})
+    assert step["type"] is FlowResultType.FORM
+    assert step["step_id"] == "move"
+    assert step["description_placeholders"]["warning"]
+
+    step = await flow.async_step_move({CONF_MANAGE_HTTP: True})
+    assert step["type"] is FlowResultType.CREATE_ENTRY
+    assert step["data"][CONF_MANAGE_HTTP] is True
+    assert step["data"][CONF_BIND_ADDRESS] == "127.0.0.1"
 
 
 def _default(step: Any, field: str) -> Any:

--- a/tests/test_deployment_guard.py
+++ b/tests/test_deployment_guard.py
@@ -9,7 +9,10 @@ import pytest
 from homeassistant.core import HomeAssistant
 from homeassistant.setup import async_setup_component
 
-from custom_components.ha_rbac.util import async_upstream_is_loopback_only
+from custom_components.ha_rbac.util import (
+    async_upstream_is_loopback_only,
+    is_loopback_bind,
+)
 
 
 @pytest.mark.parametrize(
@@ -43,3 +46,26 @@ async def test_unparseable_host_is_treated_as_exposed(hass: HomeAssistant) -> No
     hass.http.server_host = ["not-an-ip"]
 
     assert async_upstream_is_loopback_only(hass) is False
+
+
+@pytest.mark.parametrize(
+    ("address", "expected"),
+    [
+        pytest.param("127.0.0.1", True, id="loopback"),
+        pytest.param("127.0.0.2", True, id="loopback-block"),
+        pytest.param(" 127.0.0.1 ", True, id="whitespace"),
+        pytest.param("::1", True, id="loopback-v6"),
+        pytest.param("::ffff:127.0.0.1", True, id="mapped-v4"),
+        pytest.param("localhost", True, id="localhost"),
+        pytest.param("0.0.0.0", False, id="all-interfaces"),
+        pytest.param("192.168.1.10", False, id="lan-address"),
+        pytest.param("not-an-ip", False, id="unparseable"),
+    ],
+)
+def test_bind_loopback_detection(address: str, expected: bool) -> None:
+    """The whole 127.0.0.0/8 block counts, not just 127.0.0.1.
+
+    A string match on the one address let 127.0.0.2 and IPv4-mapped forms
+    through, so binding to those looked reachable when it was not.
+    """
+    assert is_loopback_bind(address) is expected


### PR DESCRIPTION
A loopback bind address with manage_http moves both HA and the proxy onto 127.0.0.1, leaving nothing reachable from the network. Validated in the config flow, options flow, and settings/set. Also surfaces the manage_http toggle in the Settings tab (subsumes #5).