### PR TITLE
Show the person being recorded the Home Assistant they actually use

### DIFF
--- a/custom_components/ha_rbac/decide.py
+++ b/custom_components/ha_rbac/decide.py
@@ -249,6 +249,20 @@ class Decider:
         self._recorder = recorder
 
     @callback
+    def is_recording(self, permissions: Permissions) -> bool:
+        """Return True if a recording covers this user.
+
+        The proxy needs this on the way back as well as on the way in. A
+        recording allows every request and filters no response, and the two
+        halves have to agree: allowing the request and then filtering the reply
+        against rules the recording is meant to be suspending shows the person
+        an empty Home Assistant, which is nothing like the one they use.
+        """
+        if self._recorder is None:
+            return False
+        return self._recorder.for_permissions(permissions) is not None
+
+    @callback
     def _resource_message(
         self, permissions: Permissions, denied: list[str], key: str
     ) -> str:

--- a/custom_components/ha_rbac/frontend/ha-rbac-panel.js
+++ b/custom_components/ha_rbac/frontend/ha-rbac-panel.js
@@ -415,6 +415,7 @@ class HaRbacPanel extends HTMLElement {
     this._denials = [];
     this._catalog = null;
     this._recording = {};
+    this._recordTimer = null;
     // Which sections are open, kept across renders: saving a role should
     // not fold away the section you were working in.
     this._open = new Set();
@@ -475,6 +476,8 @@ class HaRbacPanel extends HTMLElement {
 
   disconnectedCallback() {
     if (this._onPopState) window.removeEventListener("popstate", this._onPopState);
+    if (this._recordTimer) clearInterval(this._recordTimer);
+    this._recordTimer = null;
   }
 
   /**
@@ -564,6 +567,7 @@ class HaRbacPanel extends HTMLElement {
     if (this._tab === "roles") this._mountEditor();
     else if (this._tab === "settings") this._mountSettings();
     this._wire();
+    this._syncRecordPoll();
   }
 
   _chrome() {
@@ -976,6 +980,61 @@ class HaRbacPanel extends HTMLElement {
           <ha-button id="record-discard" class="quiet">Discard</ha-button>
         </div>
       </div>`;
+  }
+
+  /**
+   * Keep the running total in step with what the recording has actually seen.
+   *
+   * A recording only fills up while somebody else is using Home Assistant, so
+   * the panel has nothing to re-render on: without this the count sits at
+   * whatever it was when the page loaded, and the only way to move it is to
+   * save the role, which reloads everything as a side effect. Only
+   * `record/status` is fetched, so an unsaved draft is never read back over.
+   */
+  _syncRecordPoll() {
+    const running = this._tab === "roles" && Object.keys(this._recording).length;
+    if (!running) {
+      if (this._recordTimer) clearInterval(this._recordTimer);
+      this._recordTimer = null;
+      return;
+    }
+    if (this._recordTimer) return;
+    this._recordTimer = setInterval(() => this._pollRecording(), 5000);
+  }
+
+  async _pollRecording() {
+    let status;
+    try {
+      status = await this._call("record/status");
+    } catch (err) {
+      // A dropped connection is the panel's problem, not the recording's;
+      // the next tick picks it up again.
+      return;
+    }
+    const was = Object.keys(this._recording).length;
+    this._recording = status || {};
+    // A restart ends every recording, and stopping one from another tab ends
+    // that one. Either way the editor is now out of date, so re-read it.
+    if (was && !Object.keys(this._recording).length) {
+      this._syncRecordPoll();
+      await this._refresh();
+      return;
+    }
+    this._mountRecordSection();
+  }
+
+  /** Redraw the recording block alone, leaving the rest of the form alone. */
+  _mountRecordSection() {
+    const host = this.shadowRoot && this.shadowRoot.getElementById("record-host");
+    if (!host || !this._draft) return;
+    host.innerHTML = this._recordSection(this._draft.system_generated);
+    const on = (id, handler) => {
+      const el = host.querySelector(`#${id}`);
+      if (el) el.addEventListener("click", handler);
+    };
+    on("record-start", () => this._record("start"));
+    on("record-stop", () => this._record("keep"));
+    on("record-discard", () => this._record("discard"));
   }
 
   async _record(action) {

--- a/custom_components/ha_rbac/proxy.py
+++ b/custom_components/ha_rbac/proxy.py
@@ -745,6 +745,18 @@ class _WsSession:
         """Return True if this connection needs no inspection at all."""
         return self._permissions.full_access
 
+    @property
+    def _unfiltered(self) -> bool:
+        """Return True if replies on this connection go back untouched.
+
+        Either because the role is unrestricted, or because it is being
+        recorded. A recording is a temporary grant of full access, so it has to
+        reach the responses too: the requests are already allowed, and
+        filtering what comes back against the very rules being suspended leaves
+        the person with an empty screen and the recording with nothing to see.
+        """
+        return self._full_access or self._decider.is_recording(self._permissions)
+
     async def pump_inbound(self) -> None:
         """Relay client -> Home Assistant, deciding on each command."""
         try:
@@ -975,7 +987,7 @@ class _WsSession:
 
         messages = parsed if isinstance(parsed, list) else [parsed]
 
-        if self._full_access:
+        if self._unfiltered:
             # Nothing is filtered here, but the ingress session still has to be
             # tied to its user: this connection is the only place the command
             # that mints one is visible, and an unrecorded session is refused

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -29,6 +29,7 @@ from custom_components.ha_rbac.filters import REGISTRY
 from custom_components.ha_rbac.ingress import SESSION_ENDPOINT
 from custom_components.ha_rbac.policy import Evaluator, Permissions
 from custom_components.ha_rbac.proxy import RbacProxy, _WsSession
+from custom_components.ha_rbac.record import Recorder
 from custom_components.ha_rbac.store import RbacStore
 
 
@@ -82,7 +83,8 @@ async def proxy_env_fixture(
     catalog.rebuild()
     evaluator = Evaluator(hass, store)
     denylog = DenyLog(hass)
-    decider = Decider(hass, catalog, REGISTRY)
+    recorder = Recorder()
+    decider = Decider(hass, catalog, REGISTRY, recorder)
 
     port = _free_port()
     proxy = RbacProxy(
@@ -102,6 +104,7 @@ async def proxy_env_fixture(
         "proxy": proxy,
         "store": store,
         "denylog": denylog,
+        "recorder": recorder,
         "base": f"http://127.0.0.1:{port}",
         "ws": f"http://127.0.0.1:{port}/api/websocket",
         "admin_token": hass_access_token,
@@ -165,6 +168,53 @@ async def test_get_states_is_filtered(proxy_env: dict[str, Any]) -> None:
     entity_ids = {state["entity_id"] for state in message["result"]}
     assert "light.kitchen" in entity_ids
     assert "lock.front" not in entity_ids
+
+
+async def test_a_recorded_role_sees_the_whole_instance(
+    proxy_env: dict[str, Any],
+) -> None:
+    """Recording suspends the response filter as well as the request gate.
+
+    Reported as "recording user activity doesn't seem to go anywhere": the
+    request side allowed everything and noted it, but the reply was still
+    filtered against the rules the recording is meant to be suspending. The
+    person being recorded saw an empty Home Assistant, could therefore touch
+    nothing, and the recording came back with nothing in it.
+    """
+    hass, store = proxy_env["hass"], proxy_env["store"]
+    hass.states.async_set("light.kitchen", "on")
+    hass.states.async_set("lock.front", "locked")
+
+    user, token = proxy_env["read_only_user"], proxy_env["read_only_token"]
+    role = await store.async_create_role({"name": "Guests", "allow": {}, "deny": {}})
+    await store.async_set_binding(user.id, [role["id"]])
+
+    async with aiohttp.ClientSession() as session:
+        ws = await _ws_login(session, proxy_env["ws"], token)
+        await ws.send_json({"id": 1, "type": "get_states"})
+        before = await asyncio.wait_for(ws.receive_json(), timeout=5)
+        await ws.close()
+
+        proxy_env["recorder"].start(role["id"])
+
+        ws = await _ws_login(session, proxy_env["ws"], token)
+        await ws.send_json({"id": 1, "type": "get_states"})
+        during = await asyncio.wait_for(ws.receive_json(), timeout=5)
+        await ws.close()
+
+        proxy_env["recorder"].stop(role["id"])
+
+        ws = await _ws_login(session, proxy_env["ws"], token)
+        await ws.send_json({"id": 1, "type": "get_states"})
+        after = await asyncio.wait_for(ws.receive_json(), timeout=5)
+        await ws.close()
+
+    seen = {state["entity_id"] for state in during["result"]}
+    assert {"light.kitchen", "lock.front"} <= seen
+    # And it is the recording doing it, not the role: the same role sees
+    # nothing either side of it.
+    assert before["result"] == []
+    assert after["result"] == []
 
 
 async def test_a_templates_value_never_reaches_a_denied_reader(


### PR DESCRIPTION
Fixes #8.

## What was happening

Recording is documented as a temporary grant of full access — `record.py`'s module docstring says its holders "are unrestricted and everything they touch is noted", and `_observe` says outright that "nothing is filtered on the way back either".

The request half does that. `decide()` checks the recorder above every gate and returns `Decision(allowed=True, filter_response=False)`. The websocket response half never looked. `_on_server_text` short-circuited on `_full_access` only, so every reply on a recorded connection went through `REGISTRY.filter_result` against `FilterContext.for_user(hass, self._permissions)` — the role's own rules, the ones the recording exists to suspend.

So the person being recorded got an empty `get_states`, an empty entity registry, and a blank screen. They could not open a dashboard, could not click an entity, could not generate anything to record. The recording ended holding nothing, and applying nothing changed nothing — which is what the reporter saw.

The HTTP path was already correct: `proxy.py:503` honours `decision.filter_response`. It was websocket-only, which is why it went unnoticed.

## Reproduced on the test VM

`hassio13`, a role allowing no entities, the Guest user bound to it and driven through the requests a browser actually sends:

| | before | after |
|---|---|---|
| states visible while recorded | 0 of 138 | **138 of 138** |
| entity registry while recorded | 0 entries | **126 entries** |
| what the recording held | 0 entities, 0 apps | **2 entities, 1 app** |
| states visible once applied | 0 | **2** — enforcement back, limited to what was recorded |

The integration's own log, same box, twelve minutes apart:

```
09:26:25  Stopped recording role 87c43e02… : 0 entities, 0 apps    ← shipped build
09:27:37  Stopped recording role 29881028… : 2 entities, 1 apps    ← patched build
```

## The change

`Decider.is_recording()` exposes the lookup `decide()` already does, and `_WsSession._unfiltered` folds it in beside `_full_access` at the one place responses are filtered. The inbound path is deliberately untouched: it must keep running `decide()`, because that is what notes the entities.

`test_a_recorded_role_sees_the_whole_instance` drives the real proxy end to end and fails without the fix. The `proxy_env` fixture now builds its `Decider` with a `Recorder`, as production does.

## Second half of the report

> I have to save the page in order to see the number of entities, apps update.

Also real, and separate. Nothing re-read `record/status` while a recording ran, so "Seen so far" sat at whatever it was when the page loaded; saving the role happened to reload everything, which is how the reporter found the workaround. The panel now polls every 5s while a recording is running and redraws that block alone — only `record/status` is fetched, so an unsaved draft is never read back over the top. The timer stops when the recording ends, when you leave the Roles tab, and on disconnect; if a recording vanishes (a restart ends them all) it falls back to a full refresh.

This part is verified by review and `node --check` only — there is no JS test harness, and driving the panel needs a browser login.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01S8bNcjr2KjfVNvFHfjhaNM