### PR TITLE
Give the proxy its own client session

### DIFF
--- a/custom_components/ha_rbac/proxy.py
+++ b/custom_components/ha_rbac/proxy.py
@@ -22,11 +22,17 @@ from ipaddress import ip_address, ip_network
 from typing import Any
 
 import aiohttp
-from aiohttp import ClientTimeout, ClientWebSocketResponse, hdrs, web
+from aiohttp import (
+    ClientSession,
+    ClientTimeout,
+    ClientWebSocketResponse,
+    TCPConnector,
+    hdrs,
+    web,
+)
 from aiohttp.helpers import must_be_empty_body
 from homeassistant.auth.models import User
 from homeassistant.core import HomeAssistant, callback
-from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.util.async_ import create_eager_task
 from homeassistant.util.json import json_loads
 from multidict import CIMultiDict
@@ -196,11 +202,12 @@ class RbacProxy:
                     "Ignoring unparseable trusted proxy at position %d", position
                 )
         self._runner: web.AppRunner | None = None
-        self._websession = async_get_clientsession(hass)
+        self._websession: ClientSession | None = None
         self._ingress = IngressGuard(hass)
 
     async def async_start(self) -> None:
         """Bind the listener."""
+        self._websession = ClientSession(connector=TCPConnector(limit=0))
         app = web.Application(client_max_size=1024**3)
         # Mounted at "/" with no prefix: signed paths are an HMAC over the exact
         # path, so any rewriting breaks every camera snapshot and download link.
@@ -282,6 +289,9 @@ class RbacProxy:
                     "this proxy is most likely the one that asked it to stop",
                     SHUTDOWN_DRAIN,
                 )
+        if self._websession is not None:
+            session, self._websession = self._websession, None
+            await session.close()
 
     @callback
     def _upstream_url(self, request: web.Request) -> URL:

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -18,6 +18,7 @@ import pytest
 from aiohttp import web
 from homeassistant.components.http.auth import async_sign_path
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.setup import async_setup_component
 from pytest_homeassistant_custom_component.common import MockUser
 
@@ -755,3 +756,35 @@ async def test_the_login_flow_still_reaches_home_assistant(
         ) as response,
     ):
         assert response.status != HTTPStatus.UNAUTHORIZED
+
+
+async def test_the_proxy_does_not_relay_through_home_assistants_shared_session(
+    proxy_env: dict[str, Any],
+) -> None:
+    """A relayed websocket holds its upstream connection for the whole session.
+
+    Drawing those from Home Assistant's shared pool let a burst of clients
+    exhaust it, and a forwarded request with no timeout then waited on a free
+    connection forever, so the proxy stopped answering while still bound. The
+    proxy keeps its own connector instead.
+    """
+    proxy = proxy_env["proxy"]
+    shared = async_get_clientsession(proxy_env["hass"])
+
+    assert proxy._websession is not None
+    assert proxy._websession is not shared
+    assert proxy._websession._connector.limit == 0
+
+
+async def test_stopping_the_proxy_closes_its_session(
+    proxy_env: dict[str, Any],
+) -> None:
+    """The session is the proxy's own, so nothing else will close it."""
+    proxy = proxy_env["proxy"]
+    session = proxy._websession
+    assert session is not None
+
+    await proxy.async_stop()
+
+    assert session.closed
+    assert proxy._websession is None


### PR DESCRIPTION
Relaying every request and websocket through HA's shared client session drew long-lived upstream connections from the pool HA needs for its own outbound calls. A burst of clients could exhaust it, and a forwarded request (no timeout) then waited on a free connection forever — the proxy stopped answering while still bound. Surfaced by an iOS onboarding token-refresh storm that later left the proxy timing out.

The proxy now owns a ClientSession with an unbounded connector, closed on stop.

Fixes #17