### PR TITLE
Advertise the proxy port over zeroconf

### DIFF
--- a/custom_components/ha_rbac/__init__.py
+++ b/custom_components/ha_rbac/__init__.py
@@ -29,7 +29,7 @@ from homeassistant.helpers import (
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.loader import async_get_integration
 
-from . import http_config, websocket_api
+from . import discovery, http_config, websocket_api
 from .catalog import Catalog
 from .const import (
     CONF_BIND_ADDRESS,
@@ -281,6 +281,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         await proxy.async_start()
         data.proxy = proxy
         await _confirm_move()
+        if manage_http:
+            await discovery.async_advertise_proxy_port(hass, upstream_port, proxy_port)
         # Dashboards can only be read once Home Assistant has loaded them.
         await dashboard_entities.async_start()
 

--- a/custom_components/ha_rbac/__init__.py
+++ b/custom_components/ha_rbac/__init__.py
@@ -287,7 +287,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             # Only once the move is permanent. Until then Home Assistant may
             # still return to the port it came from, and an advertisement
             # pointing at the proxy would be the wrong one to leave behind.
-            await discovery.async_advertise_proxy_port(hass, upstream_port, proxy_port)
+            await discovery.async_advertise_proxy_port(hass, proxy_port)
         # Dashboards can only be read once Home Assistant has loaded them.
         await dashboard_entities.async_start()
 

--- a/custom_components/ha_rbac/__init__.py
+++ b/custom_components/ha_rbac/__init__.py
@@ -226,7 +226,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         await hass.services.async_call(HA_DOMAIN, SERVICE_RESTART, blocking=False)
         return True
 
-    async def _confirm_move() -> None:
+    async def _confirm_move() -> bool:
         """Make the move permanent, but only once the proxy really serves.
 
         This is the interlock the whole thing rests on. Until it runs, Home
@@ -234,9 +234,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         that binds but cannot forward still leaves a way back in. Promoting on
         `async_start` alone would throw that away, since binding a port says
         nothing about whether anything answers on it.
+
+        Returns True if the move was confirmed and made permanent.
         """
         if not manage_http:
-            return
+            return False
         bind = config.get(CONF_BIND_ADDRESS, DEFAULT_BIND_ADDRESS)
         reachable = "127.0.0.1" if bind in ("0.0.0.0", "::", "") else bind
         try:
@@ -253,9 +255,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
                 proxy_port,
                 err,
             )
-            return
+            return False
         if served:
             await http_config.async_promote(hass)
+        return served
 
     async def _start_proxy(_event: Event | None = None) -> None:
         """Start the listener once Home Assistant is serving."""
@@ -280,8 +283,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         )
         await proxy.async_start()
         data.proxy = proxy
-        await _confirm_move()
-        if manage_http:
+        if await _confirm_move():
+            # Only once the move is permanent. Until then Home Assistant may
+            # still return to the port it came from, and an advertisement
+            # pointing at the proxy would be the wrong one to leave behind.
             await discovery.async_advertise_proxy_port(hass, upstream_port, proxy_port)
         # Dashboards can only be read once Home Assistant has loaded them.
         await dashboard_entities.async_start()

--- a/custom_components/ha_rbac/discovery.py
+++ b/custom_components/ha_rbac/discovery.py
@@ -6,10 +6,10 @@ port it binds, which is now the one nothing off the machine can reach. The
 companion apps discover that port and offer it, so a fresh install auto-detects
 an address it cannot connect to.
 
-This re-registers the same service with the port the proxy actually answers on.
-None of the API is public, so every entry point degrades to "left it alone"
-rather than raising: a broken advertisement is a worse setup experience, not a
-broken instance.
+This corrects the record Home Assistant already registered so it names the port
+the proxy actually answers on. None of the API is public, so every entry point
+degrades to "left it alone" rather than raising: a broken advertisement is a
+worse setup experience, not a broken instance.
 """
 
 import logging
@@ -25,7 +25,7 @@ class Unavailable(Exception):
 
 
 def _api() -> Any:
-    """Return the zeroconf module and service-info class, or raise Unavailable."""
+    """Return the zeroconf module, the service type and the info class."""
     try:
         from homeassistant.components import zeroconf  # noqa: PLC0415
         from homeassistant.components.zeroconf.const import (  # noqa: PLC0415
@@ -34,9 +34,8 @@ def _api() -> Any:
         from zeroconf.asyncio import AsyncServiceInfo  # noqa: PLC0415
     except ImportError as err:
         raise Unavailable(str(err)) from err
-    for name in ("async_get_async_instance", "_async_get_local_service_info"):
-        if not hasattr(zeroconf, name):
-            raise Unavailable(f"homeassistant.components.zeroconf has no {name}")
+    if not hasattr(zeroconf, "async_get_async_instance"):
+        raise Unavailable("homeassistant.components.zeroconf has no instance getter")
     return zeroconf, ZEROCONF_TYPE, AsyncServiceInfo
 
 
@@ -51,10 +50,21 @@ def _rewrite_port(value: str, hidden_port: int, proxy_port: int) -> str:
     return value.replace(f":{hidden_port}", f":{proxy_port}")
 
 
-async def async_advertise_proxy_port(
-    hass: HomeAssistant, hidden_port: int, proxy_port: int
-) -> bool:
-    """Re-register the instance's zeroconf service on the proxy port.
+def _registered(aio_zc: Any, zeroconf_type: str) -> Any:
+    """Return the instance's own registered service record.
+
+    Raises Unavailable if there is not exactly one to correct. None means the
+    broadcast has not started yet, and registering one here would be racing
+    Home Assistant for the name rather than fixing what it published.
+    """
+    infos = aio_zc.zeroconf.registry.async_get_infos_type(zeroconf_type)
+    if len(infos) != 1:
+        raise Unavailable(f"{len(infos)} local records registered for {zeroconf_type}")
+    return infos[0]
+
+
+async def async_advertise_proxy_port(hass: HomeAssistant, proxy_port: int) -> bool:
+    """Point the instance's zeroconf record at the proxy port.
 
     Returns True if the advertisement was updated.
     """
@@ -63,13 +73,13 @@ async def async_advertise_proxy_port(
     try:
         zeroconf, zeroconf_type, service_info_cls = _api()
         aio_zc = await zeroconf.async_get_async_instance(hass)
-        info = await zeroconf._async_get_local_service_info(hass)  # noqa: SLF001
+        info = _registered(aio_zc, zeroconf_type)
         if info.port == proxy_port:
             return False
 
         properties = {
             key: (
-                _rewrite_port(value, hidden_port, proxy_port)
+                _rewrite_port(value, info.port, proxy_port)
                 if isinstance(value, str)
                 else value
             )
@@ -84,8 +94,17 @@ async def async_advertise_proxy_port(
             port=proxy_port,
             properties=properties,
         )
-        await aio_zc.async_register_service(corrected, allow_name_change=True)
-    except (Unavailable, OSError, RuntimeError, AttributeError) as err:
+        # Updated, not registered afresh. Registering replays the name check,
+        # and the name is already answering on the network -- its own. So
+        # zeroconf takes it for a collision, renames this record to "<name>-2"
+        # and leaves the original, still naming the port nothing can reach,
+        # registered beside it. Two instances would show up in the companion
+        # app, and the one that reads as the real one would be the broken one.
+        await aio_zc.async_update_service(corrected)
+    except Exception as err:  # noqa: BLE001
+        # Deliberately broad, for the reason in the module docstring: none of
+        # this is API anyone promised to keep, and every way it can be gone has
+        # to come back as "the advertisement is as Home Assistant left it".
         _LOGGER.debug("Could not advertise the proxy port over zeroconf: %s", err)
         return False
     _LOGGER.info("Advertising Home Assistant on port %s over zeroconf", proxy_port)

--- a/custom_components/ha_rbac/discovery.py
+++ b/custom_components/ha_rbac/discovery.py
@@ -1,0 +1,92 @@
+"""Advertise the proxy's port over zeroconf.
+
+Moving Home Assistant to a hidden loopback port takes its own
+`_home-assistant._tcp.local.` broadcast with it: Home Assistant advertises the
+port it binds, which is now the one nothing off the machine can reach. The
+companion apps discover that port and offer it, so a fresh install auto-detects
+an address it cannot connect to.
+
+This re-registers the same service with the port the proxy actually answers on.
+None of the API is public, so every entry point degrades to "left it alone"
+rather than raising: a broken advertisement is a worse setup experience, not a
+broken instance.
+"""
+
+import logging
+from typing import Any
+
+from homeassistant.core import HomeAssistant
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class Unavailable(Exception):
+    """Home Assistant does not expose zeroconf the way this expects."""
+
+
+def _api() -> Any:
+    """Return the zeroconf module and service-info class, or raise Unavailable."""
+    try:
+        from homeassistant.components import zeroconf  # noqa: PLC0415
+        from homeassistant.components.zeroconf.const import (  # noqa: PLC0415
+            ZEROCONF_TYPE,
+        )
+        from zeroconf.asyncio import AsyncServiceInfo  # noqa: PLC0415
+    except ImportError as err:
+        raise Unavailable(str(err)) from err
+    for name in ("async_get_async_instance", "_async_get_local_service_info"):
+        if not hasattr(zeroconf, name):
+            raise Unavailable(f"homeassistant.components.zeroconf has no {name}")
+    return zeroconf, ZEROCONF_TYPE, AsyncServiceInfo
+
+
+def _rewrite_port(value: str, hidden_port: int, proxy_port: int) -> str:
+    """Return a URL property with the hidden port swapped for the proxy port.
+
+    Only a URL that names the hidden port is touched. A user who configured an
+    explicit internal or external URL meant it, and it is left as it stands.
+    """
+    if not value:
+        return value
+    return value.replace(f":{hidden_port}", f":{proxy_port}")
+
+
+async def async_advertise_proxy_port(
+    hass: HomeAssistant, hidden_port: int, proxy_port: int
+) -> bool:
+    """Re-register the instance's zeroconf service on the proxy port.
+
+    Returns True if the advertisement was updated.
+    """
+    if "zeroconf" not in hass.config.components:
+        return False
+    try:
+        zeroconf, zeroconf_type, service_info_cls = _api()
+        aio_zc = await zeroconf.async_get_async_instance(hass)
+        info = await zeroconf._async_get_local_service_info(hass)  # noqa: SLF001
+        if info.port == proxy_port:
+            return False
+
+        properties = {
+            key: (
+                _rewrite_port(value, hidden_port, proxy_port)
+                if isinstance(value, str)
+                else value
+            )
+            for key, value in dict(info.decoded_properties).items()
+        }
+
+        corrected = service_info_cls(
+            zeroconf_type,
+            name=info.name,
+            server=info.server,
+            parsed_addresses=info.parsed_addresses(),
+            port=proxy_port,
+            properties=properties,
+        )
+        await aio_zc.async_register_service(corrected, allow_name_change=True)
+    except (Unavailable, OSError, RuntimeError, AttributeError) as err:
+        _LOGGER.debug("Could not advertise the proxy port over zeroconf: %s", err)
+        return False
+    _LOGGER.info("Advertising Home Assistant on port %s over zeroconf", proxy_port)
+    return True

--- a/custom_components/ha_rbac/manifest.json
+++ b/custom_components/ha_rbac/manifest.json
@@ -3,7 +3,8 @@
   "name": "RBAC Access Control",
   "after_dependencies": [
     "hassio",
-    "lovelace"
+    "lovelace",
+    "zeroconf"
   ],
   "codeowners": [
     "@FezVrasta"

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -1,26 +1,33 @@
 """Tests for advertising the proxy port over zeroconf.
 
 Moving Home Assistant to a hidden port takes its own broadcast with it, so the
-companion apps discover a port they cannot reach. These pin that the service is
-re-registered on the port the proxy actually answers on.
+companion apps discover a port they cannot reach. These pin that the record
+Home Assistant registered ends up naming the port the proxy answers on.
+
+They drive zeroconf's real `ServiceRegistry` rather than a mock, because the
+way this breaks is a second record appearing beside the first -- which a mock
+records as a call and reports as a pass.
 """
 
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, patch
 
 from homeassistant.core import HomeAssistant
+from zeroconf import ServiceRegistry
 from zeroconf.asyncio import AsyncServiceInfo
 
 from custom_components.ha_rbac import discovery
 
 HIDDEN_PORT = 8124
 PROXY_PORT = 8123
+ZEROCONF_TYPE = "_home-assistant._tcp.local."
 
 
 def _service_info(port: int) -> AsyncServiceInfo:
     """Build a service info the way Home Assistant does, on a given port."""
     return AsyncServiceInfo(
-        "_home-assistant._tcp.local.",
-        name="Home._home-assistant._tcp.local.",
+        ZEROCONF_TYPE,
+        name=f"Home.{ZEROCONF_TYPE}",
         server="uuid.local.",
         parsed_addresses=["192.168.1.10"],
         port=port,
@@ -28,41 +35,83 @@ def _service_info(port: int) -> AsyncServiceInfo:
             "location_name": "Home",
             "uuid": "uuid",
             "version": "2026.9.0",
-            "base_url": f"http://192.168.1.10:{HIDDEN_PORT}",
-            "internal_url": f"http://192.168.1.10:{HIDDEN_PORT}",
+            "base_url": f"http://192.168.1.10:{port}",
+            "internal_url": f"http://192.168.1.10:{port}",
             "external_url": "",
         },
     )
 
 
-async def test_the_service_is_re_registered_on_the_proxy_port(
+class _FakeAsyncZeroconf:
+    """The half of `HaAsyncZeroconf` this touches, over a real registry."""
+
+    def __init__(self, registered: AsyncServiceInfo | None = None) -> None:
+        """Start from what Home Assistant has already broadcast, if anything."""
+        self.registry = ServiceRegistry()
+        if registered is not None:
+            self.registry.async_add(registered)
+        self.zeroconf = SimpleNamespace(registry=self.registry)
+
+    async def async_update_service(self, info: AsyncServiceInfo) -> None:
+        """Replace the record under its own name, as zeroconf does."""
+        self.registry.async_update(info)
+
+    async def async_register_service(self, info: AsyncServiceInfo, **kwargs) -> None:
+        """Fail the way zeroconf does when the name is already taken."""
+        raise AssertionError("the record is Home Assistant's to hold, not ours to add")
+
+
+def _advertising(zeroconf: _FakeAsyncZeroconf) -> list[tuple[str, int]]:
+    """Return every record being broadcast for the Home Assistant service."""
+    return [
+        (info.name, info.port)
+        for info in zeroconf.registry.async_get_infos_type(ZEROCONF_TYPE)
+    ]
+
+
+def _patch(zeroconf: _FakeAsyncZeroconf | AsyncMock) -> object:
+    """Hand the integration our zeroconf instance instead of the real one."""
+    return patch(
+        "homeassistant.components.zeroconf.async_get_async_instance",
+        AsyncMock(return_value=zeroconf),
+    )
+
+
+async def test_the_advertised_record_moves_to_the_proxy_port(
     hass: HomeAssistant,
 ) -> None:
     """The port and the URL properties both move to the proxy's port."""
     hass.config.components.add("zeroconf")
-    aio_zc = AsyncMock()
+    zeroconf = _FakeAsyncZeroconf(_service_info(HIDDEN_PORT))
 
-    with (
-        patch(
-            "homeassistant.components.zeroconf.async_get_async_instance",
-            AsyncMock(return_value=aio_zc),
-        ),
-        patch(
-            "homeassistant.components.zeroconf._async_get_local_service_info",
-            AsyncMock(return_value=_service_info(HIDDEN_PORT)),
-        ),
-    ):
-        updated = await discovery.async_advertise_proxy_port(
-            hass, HIDDEN_PORT, PROXY_PORT
-        )
+    with _patch(zeroconf):
+        updated = await discovery.async_advertise_proxy_port(hass, PROXY_PORT)
 
     assert updated is True
-    aio_zc.async_register_service.assert_awaited_once()
-    registered = aio_zc.async_register_service.await_args.args[0]
+    (registered,) = zeroconf.registry.async_get_infos_type(ZEROCONF_TYPE)
     assert registered.port == PROXY_PORT
     props = registered.decoded_properties
     assert props["internal_url"] == f"http://192.168.1.10:{PROXY_PORT}"
     assert props["base_url"] == f"http://192.168.1.10:{PROXY_PORT}"
+    assert props["uuid"] == "uuid"
+
+
+async def test_the_correction_replaces_the_record_rather_than_joining_it(
+    hass: HomeAssistant,
+) -> None:
+    """One instance is advertised, under the name it already had.
+
+    Registering the corrected record instead of updating it renames it to
+    "Home-2" and leaves the original -- pointing at the hidden port -- beside
+    it, which is a worse answer than not correcting it at all.
+    """
+    hass.config.components.add("zeroconf")
+    zeroconf = _FakeAsyncZeroconf(_service_info(HIDDEN_PORT))
+
+    with _patch(zeroconf):
+        await discovery.async_advertise_proxy_port(hass, PROXY_PORT)
+
+    assert _advertising(zeroconf) == [(f"Home.{ZEROCONF_TYPE}", PROXY_PORT)]
 
 
 async def test_nothing_happens_when_already_on_the_proxy_port(
@@ -70,24 +119,31 @@ async def test_nothing_happens_when_already_on_the_proxy_port(
 ) -> None:
     """A record that already names the proxy port needs no rewrite."""
     hass.config.components.add("zeroconf")
-    aio_zc = AsyncMock()
+    zeroconf = _FakeAsyncZeroconf(_service_info(PROXY_PORT))
 
-    with (
-        patch(
-            "homeassistant.components.zeroconf.async_get_async_instance",
-            AsyncMock(return_value=aio_zc),
-        ),
-        patch(
-            "homeassistant.components.zeroconf._async_get_local_service_info",
-            AsyncMock(return_value=_service_info(PROXY_PORT)),
-        ),
-    ):
-        updated = await discovery.async_advertise_proxy_port(
-            hass, HIDDEN_PORT, PROXY_PORT
-        )
+    with _patch(zeroconf):
+        updated = await discovery.async_advertise_proxy_port(hass, PROXY_PORT)
 
     assert updated is False
-    aio_zc.async_register_service.assert_not_awaited()
+    assert _advertising(zeroconf) == [(f"Home.{ZEROCONF_TYPE}", PROXY_PORT)]
+
+
+async def test_nothing_is_advertised_before_home_assistant_broadcasts(
+    hass: HomeAssistant,
+) -> None:
+    """With no record registered yet, this has nothing to correct.
+
+    Adding one here would be racing Home Assistant for its own name rather
+    than fixing what it published.
+    """
+    hass.config.components.add("zeroconf")
+    zeroconf = _FakeAsyncZeroconf()
+
+    with _patch(zeroconf):
+        updated = await discovery.async_advertise_proxy_port(hass, PROXY_PORT)
+
+    assert updated is False
+    assert _advertising(zeroconf) == []
 
 
 async def test_a_missing_zeroconf_api_is_survived(hass: HomeAssistant) -> None:
@@ -97,9 +153,16 @@ async def test_a_missing_zeroconf_api_is_survived(hass: HomeAssistant) -> None:
         "homeassistant.components.zeroconf.async_get_async_instance",
         AsyncMock(side_effect=RuntimeError("no zeroconf")),
     ):
-        updated = await discovery.async_advertise_proxy_port(
-            hass, HIDDEN_PORT, PROXY_PORT
-        )
+        updated = await discovery.async_advertise_proxy_port(hass, PROXY_PORT)
+
+    assert updated is False
+
+
+async def test_a_drifted_zeroconf_api_is_survived(hass: HomeAssistant) -> None:
+    """An instance that no longer keeps a registry is not reached into."""
+    hass.config.components.add("zeroconf")
+    with _patch(SimpleNamespace(zeroconf=SimpleNamespace())):
+        updated = await discovery.async_advertise_proxy_port(hass, PROXY_PORT)
 
     assert updated is False
 
@@ -111,9 +174,7 @@ async def test_nothing_happens_when_zeroconf_is_not_loaded(
     with patch(
         "homeassistant.components.zeroconf.async_get_async_instance"
     ) as get_instance:
-        updated = await discovery.async_advertise_proxy_port(
-            hass, HIDDEN_PORT, PROXY_PORT
-        )
+        updated = await discovery.async_advertise_proxy_port(hass, PROXY_PORT)
 
     assert updated is False
     get_instance.assert_not_called()

--- a/tests/test_discovery.py
+++ b/tests/test_discovery.py
@@ -1,0 +1,119 @@
+"""Tests for advertising the proxy port over zeroconf.
+
+Moving Home Assistant to a hidden port takes its own broadcast with it, so the
+companion apps discover a port they cannot reach. These pin that the service is
+re-registered on the port the proxy actually answers on.
+"""
+
+from unittest.mock import AsyncMock, patch
+
+from homeassistant.core import HomeAssistant
+from zeroconf.asyncio import AsyncServiceInfo
+
+from custom_components.ha_rbac import discovery
+
+HIDDEN_PORT = 8124
+PROXY_PORT = 8123
+
+
+def _service_info(port: int) -> AsyncServiceInfo:
+    """Build a service info the way Home Assistant does, on a given port."""
+    return AsyncServiceInfo(
+        "_home-assistant._tcp.local.",
+        name="Home._home-assistant._tcp.local.",
+        server="uuid.local.",
+        parsed_addresses=["192.168.1.10"],
+        port=port,
+        properties={
+            "location_name": "Home",
+            "uuid": "uuid",
+            "version": "2026.9.0",
+            "base_url": f"http://192.168.1.10:{HIDDEN_PORT}",
+            "internal_url": f"http://192.168.1.10:{HIDDEN_PORT}",
+            "external_url": "",
+        },
+    )
+
+
+async def test_the_service_is_re_registered_on_the_proxy_port(
+    hass: HomeAssistant,
+) -> None:
+    """The port and the URL properties both move to the proxy's port."""
+    hass.config.components.add("zeroconf")
+    aio_zc = AsyncMock()
+
+    with (
+        patch(
+            "homeassistant.components.zeroconf.async_get_async_instance",
+            AsyncMock(return_value=aio_zc),
+        ),
+        patch(
+            "homeassistant.components.zeroconf._async_get_local_service_info",
+            AsyncMock(return_value=_service_info(HIDDEN_PORT)),
+        ),
+    ):
+        updated = await discovery.async_advertise_proxy_port(
+            hass, HIDDEN_PORT, PROXY_PORT
+        )
+
+    assert updated is True
+    aio_zc.async_register_service.assert_awaited_once()
+    registered = aio_zc.async_register_service.await_args.args[0]
+    assert registered.port == PROXY_PORT
+    props = registered.decoded_properties
+    assert props["internal_url"] == f"http://192.168.1.10:{PROXY_PORT}"
+    assert props["base_url"] == f"http://192.168.1.10:{PROXY_PORT}"
+
+
+async def test_nothing_happens_when_already_on_the_proxy_port(
+    hass: HomeAssistant,
+) -> None:
+    """A record that already names the proxy port needs no rewrite."""
+    hass.config.components.add("zeroconf")
+    aio_zc = AsyncMock()
+
+    with (
+        patch(
+            "homeassistant.components.zeroconf.async_get_async_instance",
+            AsyncMock(return_value=aio_zc),
+        ),
+        patch(
+            "homeassistant.components.zeroconf._async_get_local_service_info",
+            AsyncMock(return_value=_service_info(PROXY_PORT)),
+        ),
+    ):
+        updated = await discovery.async_advertise_proxy_port(
+            hass, HIDDEN_PORT, PROXY_PORT
+        )
+
+    assert updated is False
+    aio_zc.async_register_service.assert_not_awaited()
+
+
+async def test_a_missing_zeroconf_api_is_survived(hass: HomeAssistant) -> None:
+    """Every entry point degrades to leaving the advertisement alone."""
+    hass.config.components.add("zeroconf")
+    with patch(
+        "homeassistant.components.zeroconf.async_get_async_instance",
+        AsyncMock(side_effect=RuntimeError("no zeroconf")),
+    ):
+        updated = await discovery.async_advertise_proxy_port(
+            hass, HIDDEN_PORT, PROXY_PORT
+        )
+
+    assert updated is False
+
+
+async def test_nothing_happens_when_zeroconf_is_not_loaded(
+    hass: HomeAssistant,
+) -> None:
+    """With no zeroconf running, the advertisement is left alone entirely."""
+    with patch(
+        "homeassistant.components.zeroconf.async_get_async_instance"
+    ) as get_instance:
+        updated = await discovery.async_advertise_proxy_port(
+            hass, HIDDEN_PORT, PROXY_PORT
+        )
+
+    assert updated is False
+    get_instance.assert_not_called()


### PR DESCRIPTION
Moving HA to a hidden loopback port takes its own _home-assistant._tcp.local. broadcast with it — HA advertises the port it binds, now unreachable — so the companion apps auto-detect an address they cannot connect to and the user must enter the proxy URL by hand.

After the move is confirmed, this re-registers the service on the proxy port and rewrites the internal/base URL properties to match. Guarded: no zeroconf loaded, or any private-API drift, leaves the advertisement alone rather than raising.

Fixes #19