### PR TITLE
Record a full-access role, and report apps/capabilities on stop

### DIFF
--- a/custom_components/ha_rbac/decide.py
+++ b/custom_components/ha_rbac/decide.py
@@ -312,13 +312,12 @@ class Decider:
     ) -> Decision:
         """Return the verdict for one request."""
         # A role being recorded is unrestricted while the recording runs, and
-        # every request is noted instead of judged. It sits above the gates
-        # deliberately: a recording that only saw what the role already allows
-        # would tell nobody anything. It sits above the full-access short-circuit
-        # too, because the role most worth recording is a full-access one -- a
-        # recording is itself a temporary grant of full access, so skipping it
-        # for a role that already has full access would note nothing at all,
-        # which is exactly the "recording logged nothing" this exists to avoid.
+        # every request is noted instead of judged. It sits above every gate
+        # deliberately, the pass-through below included: a recording that only
+        # saw what the role already allows would tell nobody anything, and a
+        # recording is itself a temporary grant of full access -- so the role
+        # most worth recording is one that already has it, and short-circuiting
+        # first is how a recording came to note nothing at all.
         if self._recorder is not None and (
             recording := self._recorder.for_permissions(permissions)
         ):

--- a/custom_components/ha_rbac/decide.py
+++ b/custom_components/ha_rbac/decide.py
@@ -311,19 +311,23 @@ class Decider:
         query: "Mapping[str, str] | None" = None,
     ) -> Decision:
         """Return the verdict for one request."""
-        # 1. Pass-through. Owner, system users and full-access roles skip every
-        #    parse, which is what keeps the proxy cheap for administrators.
-        if permissions.full_access:
-            return Decision(allowed=True)
-
         # A role being recorded is unrestricted while the recording runs, and
         # every request is noted instead of judged. It sits above the gates
         # deliberately: a recording that only saw what the role already allows
-        # would tell nobody anything.
+        # would tell nobody anything. It sits above the full-access short-circuit
+        # too, because the role most worth recording is a full-access one -- a
+        # recording is itself a temporary grant of full access, so skipping it
+        # for a role that already has full access would note nothing at all,
+        # which is exactly the "recording logged nothing" this exists to avoid.
         if self._recorder is not None and (
             recording := self._recorder.for_permissions(permissions)
         ):
             return self._observe(recording, kind, name, payload, query)
+
+        # 1. Pass-through. Owner, system users and full-access roles skip every
+        #    parse, which is what keeps the proxy cheap for administrators.
+        if permissions.full_access:
+            return Decision(allowed=True)
 
         # If tier derivation has stopped working, every command would look
         # unrestricted. Refuse rather than fail open.

--- a/custom_components/ha_rbac/frontend/ha-rbac-panel.js
+++ b/custom_components/ha_rbac/frontend/ha-rbac-panel.js
@@ -1070,6 +1070,21 @@ class HaRbacPanel extends HTMLElement {
           ? `Added ${parts.join(", ")} to this role.`
           : "Recording captured nothing: its holders did not open or touch " +
             "anything a role controls while it ran.";
+        // Within a role a denial vetoes, so an entity recorded under a `deny`
+        // rule is added and then immediately overruled. The server works out
+        // which ones and says so rather than dropping the denial on somebody's
+        // behalf; saying nothing here would leave them to find out from a
+        // dashboard that is still empty after a recording that looked fine.
+        const blocked = result.blocked || [];
+        if (blocked.length) {
+          const one = blocked.length === 1;
+          const named = blocked.slice(0, 5).join(", ");
+          const rest = blocked.length - 5;
+          message +=
+            ` ${one ? "One entity was" : `${blocked.length} entities were`} added,` +
+            ` but a deny rule on this role still overrules ${one ? "it" : "them"}:` +
+            ` ${named}${rest > 0 ? ` and ${rest} more` : ""}.`;
+        }
       },
       () => message
     );

--- a/custom_components/ha_rbac/frontend/ha-rbac-panel.js
+++ b/custom_components/ha_rbac/frontend/ha-rbac-panel.js
@@ -1051,10 +1051,25 @@ class HaRbacPanel extends HTMLElement {
           apply: action === "keep",
         });
         const seen = result.seen || {};
-        const count = seen.entities ? Object.keys(seen.entities).length : 0;
-        message = result.applied
-          ? `Added ${count} ${count === 1 ? "entity" : "entities"} to this role.`
-          : "Recording discarded. The role is unchanged.";
+        if (!result.applied) {
+          message = "Recording discarded. The role is unchanged.";
+          return;
+        }
+        // A recording notes three kinds of thing, and only ever names an
+        // entity a request actually carried. Just viewing dashboards names
+        // none, so reporting entities alone reads as "nothing recorded" even
+        // when apps or capabilities were granted. Count all three.
+        const parts = [];
+        const entities = seen.entities ? Object.keys(seen.entities).length : 0;
+        const apps = seen.apps ? seen.apps.length : 0;
+        const caps = seen.capabilities ? seen.capabilities.length : 0;
+        if (entities) parts.push(`${entities} ${entities === 1 ? "entity" : "entities"}`);
+        if (apps) parts.push(`${apps} ${apps === 1 ? "app" : "apps"}`);
+        if (caps) parts.push(`${caps} ${caps === 1 ? "capability" : "capabilities"}`);
+        message = parts.length
+          ? `Added ${parts.join(", ")} to this role.`
+          : "Recording captured nothing: its holders did not open or touch " +
+            "anything a role controls while it ran.";
       },
       () => message
     );

--- a/custom_components/ha_rbac/proxy.py
+++ b/custom_components/ha_rbac/proxy.py
@@ -398,7 +398,10 @@ class RbacProxy:
             # holds it legitimately. Webhooks sit outside this boundary, in the
             # same place as automations and add-ons, and DESIGN.md says so.
             pass
-        elif not permissions.full_access:
+        elif not permissions.full_access or self._decider.is_recording(permissions):
+            # A full-access user is normally forwarded unjudged, but a recording
+            # has to see what an unrestricted user touches, so `decide` is still
+            # consulted: it notes the request and allows it rather than refusing.
             body = await self._peek_json(request)
             name = f"{request.method} {request.path}"
             decision = self._decider.decide(
@@ -923,7 +926,13 @@ class _WsSession:
                 self._coalesced = True
             return True
 
-        if self._full_access or not isinstance(msg_type, str):
+        # A full-access connection needs no inspection, unless one of its roles
+        # is being recorded: a recording has to see what an unrestricted user
+        # touches, so it is routed into `decide`, which notes the request and
+        # allows it rather than short-circuiting here.
+        if not isinstance(msg_type, str) or (
+            self._full_access and not self._decider.is_recording(self._permissions)
+        ):
             return True
 
         decision = self._decider.decide(self._permissions, KIND_WS, msg_type, message)

--- a/custom_components/ha_rbac/record.py
+++ b/custom_components/ha_rbac/record.py
@@ -118,7 +118,14 @@ class Recorder:
         One recording role is enough. A user holding a recorded role alongside
         an ordinary one is unrestricted for the duration, which is the point:
         the recording has to see what they would have been refused.
+
+        This is asked on every request, ahead of the full-access short-circuit
+        that keeps the proxy cheap for administrators, so the answer when
+        nothing is recording -- which is almost always -- costs one empty-dict
+        check rather than a walk over the user's roles.
         """
+        if not self._recordings:
+            return None
         for role in permissions.roles:
             if (recording := self._recordings.get(role.role_id)) is not None:
                 return recording

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -6,6 +6,7 @@ from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from homeassistant.auth.permissions.const import CAT_ENTITIES, POLICY_READ
 from homeassistant.core import HomeAssistant, ServiceCall
 from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.setup import async_setup_component
@@ -167,6 +168,63 @@ async def test_catalog_is_exposed_for_the_editor(
     assert len(result["commands"]) > 20
     assert result["degraded"] is False
     assert any(entry["tier"] == "admin" for entry in result["commands"])
+
+
+async def test_stopping_a_recording_reports_everything_it_saw(
+    hass: HomeAssistant, entry: MockConfigEntry, hass_ws_client: WebSocketGenerator
+) -> None:
+    """The panel writes its confirmation from this result, so it is pinned here.
+
+    A recording notes entities, apps and capabilities, and the confirmation has
+    to name all three -- reporting entities alone read as "recorded nothing" to
+    anyone whose recording only opened a screen. `blocked` matters as much: an
+    entity recorded under a `deny` rule is added and then overruled by it, and
+    saying so is the only warning before a dashboard that is still empty.
+    """
+    data = hass.data[DATA_RBAC]
+    role = await data.store.async_create_role(
+        {"name": "Guests", "deny": {CAT_ENTITIES: {"domains": {"lock": True}}}}
+    )
+    recording = data.recorder.start(role["id"])
+    recording.note_entity("light.kitchen", POLICY_READ)
+    recording.note_entity("lock.front", POLICY_READ)
+    recording.apps.add("lovelace")
+    recording.capabilities.add("automations")
+
+    client = await hass_ws_client(hass)
+    await client.send_json_auto_id(
+        {"type": f"{DOMAIN}/record/stop", "role_id": role["id"]}
+    )
+    result = (await client.receive_json())["result"]
+
+    assert result["applied"] is True
+    assert result["seen"]["entities"] == {
+        "light.kitchen": POLICY_READ,
+        "lock.front": POLICY_READ,
+    }
+    assert result["seen"]["apps"] == ["lovelace"]
+    assert result["seen"]["capabilities"] == ["automations"]
+    # Added to the allow side, and vetoed by the role's own denial.
+    assert result["blocked"] == ["lock.front"]
+
+
+async def test_discarding_a_recording_leaves_the_role_alone(
+    hass: HomeAssistant, entry: MockConfigEntry, hass_ws_client: WebSocketGenerator
+) -> None:
+    """Discarding is how a recording is abandoned, and it must write nothing."""
+    data = hass.data[DATA_RBAC]
+    role = await data.store.async_create_role({"name": "Guests"})
+    data.recorder.start(role["id"]).note_entity("light.kitchen", POLICY_READ)
+
+    client = await hass_ws_client(hass)
+    await client.send_json_auto_id(
+        {"type": f"{DOMAIN}/record/stop", "role_id": role["id"], "apply": False}
+    )
+    result = (await client.receive_json())["result"]
+
+    assert result["applied"] is False
+    assert result["seen"]["entities"] == {"light.kitchen": POLICY_READ}
+    assert data.store.roles[role["id"]] == role
 
 
 async def test_simulate_explains_a_denial(

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -5,6 +5,7 @@ a plain aiohttp client exercises the same path a frontend would.
 """
 
 import asyncio
+import contextlib
 import json
 import socket
 from collections import OrderedDict
@@ -240,10 +241,8 @@ async def test_recording_notes_a_toggle_on_an_already_open_connection(
 
     async def _drain(ws: Any) -> None:
         """Read the reply if it comes; the recording is noted on the way in."""
-        try:
+        with contextlib.suppress(TimeoutError):
             await asyncio.wait_for(ws.receive_json(), timeout=5)
-        except (TimeoutError, asyncio.TimeoutError):
-            pass
 
     async with aiohttp.ClientSession() as session:
         # Connect first: the browser is already open when recording begins.

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -218,6 +218,82 @@ async def test_a_recorded_role_sees_the_whole_instance(
     assert after["result"] == []
 
 
+async def test_recording_notes_a_toggle_on_an_already_open_connection(
+    proxy_env: dict[str, Any],
+) -> None:
+    """The reporter's scenario for issue #13, exactly.
+
+    A restricted role -- not admin -- is put into recording while its holder is
+    already connected, and they toggle an entity. This is the case the
+    direct-decide tests never covered: the frame has to travel the real inbound
+    path (`_intercept`, `_refresh_permissions`, the id-reuse guard) rather than
+    reaching `decide` directly, and the connection was open before recording
+    started, so it has to pick the recording up per frame rather than at auth.
+    """
+    hass, store = proxy_env["hass"], proxy_env["store"]
+    hass.states.async_set("light.kitchen", "on")
+    hass.states.async_set("script.night_lights", "off")
+
+    user, token = proxy_env["read_only_user"], proxy_env["read_only_token"]
+    role = await store.async_create_role({"name": "Guests", "allow": {}, "deny": {}})
+    await store.async_set_binding(user.id, [role["id"]])
+
+    async def _drain(ws: Any) -> None:
+        """Read the reply if it comes; the recording is noted on the way in."""
+        try:
+            await asyncio.wait_for(ws.receive_json(), timeout=5)
+        except (TimeoutError, asyncio.TimeoutError):
+            pass
+
+    async with aiohttp.ClientSession() as session:
+        # Connect first: the browser is already open when recording begins.
+        ws = await _ws_login(session, proxy_env["ws"], token)
+
+        proxy_env["recorder"].start(role["id"])
+
+        # A toggle from a dashboard: entity under target.
+        await ws.send_json(
+            {
+                "id": 1,
+                "type": "call_service",
+                "domain": "light",
+                "service": "toggle",
+                "target": {"entity_id": "light.kitchen"},
+            }
+        )
+        await _drain(ws)
+
+        # Running a script: the service is named after the entity, so the
+        # payload carries no entity at all -- only `script` / `night_lights`.
+        await ws.send_json(
+            {
+                "id": 2,
+                "type": "call_service",
+                "domain": "script",
+                "service": "night_lights",
+            }
+        )
+        await _drain(ws)
+        await ws.close()
+
+        # And the same toggle over REST, in case the frontend uses that path.
+        async with session.post(
+            f"{proxy_env['base']}/api/services/light/toggle",
+            headers={"Authorization": f"Bearer {token}"},
+            json={"entity_id": "light.kitchen"},
+        ):
+            pass
+
+    recording = proxy_env["recorder"].get(role["id"])
+    assert recording is not None
+    assert recording.entities.get("light.kitchen") == "control", (
+        f"toggle was not recorded; saw {recording.entities}"
+    )
+    assert recording.entities.get("script.night_lights") == "control", (
+        f"script run was not recorded; saw {recording.entities}"
+    )
+
+
 async def test_a_templates_value_never_reaches_a_denied_reader(
     proxy_env: dict[str, Any],
 ) -> None:

--- a/tests/test_record.py
+++ b/tests/test_record.py
@@ -233,36 +233,60 @@ async def test_a_second_role_does_not_hide_a_recording(hass: HomeAssistant) -> N
     assert recording.role_id == "guests"
 
 
-async def test_an_unrestricted_user_is_never_recorded(hass: HomeAssistant) -> None:
-    """The owner skips every gate, so there is nothing of theirs to record.
+async def test_the_owner_holds_no_roles_so_is_never_recorded(
+    hass: HomeAssistant,
+) -> None:
+    """The owner is pass-through and holds no roles, so nothing matches them.
 
-    Recording their traffic would fill the role with everything an
-    administrator does, which is the opposite of what it is for.
+    A recording is keyed on a role, and the owner carries none: there is no
+    role of theirs to fill, so their traffic is never noted.
     """
     recorder = Recorder()
     decider = await _decider(hass, recorder)
     recorder.start("guests")
 
-    full = Permissions(
-        roles=[
-            compile_role(
-                hass,
-                {
-                    "id": "guests",
-                    "name": "Guests",
-                    "allow": {CAT_ENTITIES: True},
-                    "tiers": {"max": "admin", "allow": ["*"], "deny": []},
-                },
-                PermissionLookup(er.async_get(hass), dr.async_get(hass)),
-            )
-        ]
-    )
-    assert full.full_access is True
+    owner = Permissions(pass_through=True)
+    assert owner.full_access is True
 
-    decider.decide(full, KIND_WS, "get_states", {"type": "get_states"})
+    decider.decide(owner, KIND_WS, "get_states", {"type": "get_states"})
     seen = recorder.stop("guests")
     assert seen is not None
     assert seen.entities == {}
+
+
+async def test_a_full_access_role_is_still_recorded(hass: HomeAssistant) -> None:
+    """Recording a role that already grants everything must still note things.
+
+    This is the case issue #13 hit: a recording is itself a temporary grant of
+    full access, so the natural role to record is a full-access one. The gate
+    order used to short-circuit on full access before ever consulting the
+    recorder, so the recording saw nothing. It has to sit above that check.
+    """
+    hass.states.async_set("lock.front", "locked")
+    recorder = Recorder()
+    decider = await _decider(hass, recorder)
+    recorder.start("guests")
+
+    full = _permissions(
+        hass,
+        {
+            "id": "guests",
+            "name": "Guests",
+            "allow": {CAT_ENTITIES: True},
+            "tiers": {"max": "admin", "allow": ["*"], "deny": []},
+        },
+    )
+    assert full.full_access is True
+
+    name = "config/entity_registry/get"
+    decided = decider.decide(
+        full, KIND_WS, name, {"type": name, "entity_id": "lock.front"}
+    )
+    assert decided.allowed is True
+
+    seen = recorder.stop("guests")
+    assert seen is not None
+    assert seen.entities == {"lock.front": POLICY_READ}
 
 
 async def test_an_admin_command_records_the_capability_it_belongs_to(

--- a/tests/test_regressions.py
+++ b/tests/test_regressions.py
@@ -79,6 +79,10 @@ class _AllowAll:
     def decide(*args: Any, **kwargs: Any) -> Decision:
         return Decision(allowed=True)
 
+    @staticmethod
+    def is_recording(*args: Any, **kwargs: Any) -> bool:
+        return False
+
 
 class _SentinelClient:
     """Collects the frames a session writes back to its client."""
@@ -505,6 +509,7 @@ async def test_reusing_an_id_after_eviction_is_still_refused() -> None:
     session._user = None
     session._permissions = Permissions(pass_through=True)
     session._client = _SentinelClient(sent)
+    session._decider = _AllowAll()
 
     assert await session._intercept({"id": 5, "type": "get_states"}) is True
     for filler in range(6, 6 + MAX_PENDING_IDS + 10):


### PR DESCRIPTION
Fixes the recording path for issue #13.

A full-access role captured nothing because decide() returned at the full_access short-circuit before consulting the recorder. The recording check now sits above that gate, and the proxy WS/HTTP paths route a recorded connection into decide() even when it is full access.

The Stop confirmation also counted only entities, so a recording that captured app or capability grants read as "Added 0 entities". It now reports all three and says plainly when a recording genuinely saw nothing.

Refs #13