### PR TITLE
Fix reload taking Home Assistant offline (loopback alignment)

### DIFF
--- a/custom_components/ha_rbac/http_config.py
+++ b/custom_components/ha_rbac/http_config.py
@@ -138,18 +138,52 @@ def target_config(current: dict[str, Any], upstream_port: int) -> dict[str, Any]
     return moved
 
 
+def _host_entries(server_host: object) -> list[str]:
+    """Return the bound hosts as a list, tolerating a bare string.
+
+    Home Assistant normally holds `server_host` as a list, but a config edited
+    by hand or migrated from older YAML can leave it a plain string. Treating a
+    string as an iterable would split it into characters, so `"127.0.0.1"` would
+    read as eight one-character hosts -- none of them loopback -- and alignment
+    would never be recognised.
+    """
+    if server_host is None:
+        return []
+    if isinstance(server_host, str):
+        return [server_host]
+    return [str(entry) for entry in server_host]
+
+
+def _is_loopback_host(host: str) -> bool:
+    """Return True if a bound host is a loopback address (IPv4 or IPv6)."""
+    try:
+        return ip_address(host).is_loopback
+    except ValueError:
+        return False
+
+
 def is_aligned(hass: HomeAssistant, upstream_port: int) -> bool:
     """Return True if Home Assistant already answers where the proxy expects.
 
     Read from the running server rather than the store: the store says what
     Home Assistant was asked to do, and this has to be true of what it is
     actually doing.
+
+    "Loopback only" is the question, not "exactly `["127.0.0.1"]`". Home
+    Assistant can be off the network on `::1` as well, and can hold the same
+    setting as a bare string or alongside a second loopback entry. Demanding one
+    exact spelling meant a reload saw an aligned instance as unaligned, moved it
+    again, and restarted -- every reload, which on a loopback-only instance is a
+    restart with nothing serving the public port in between.
     """
     http = getattr(hass, "http", None)
     if http is None:
         return False
-    return list(getattr(http, "server_host", None) or []) == [LOOPBACK] and (
-        getattr(http, "server_port", None) == upstream_port
+    hosts = _host_entries(getattr(http, "server_host", None))
+    return (
+        bool(hosts)
+        and all(_is_loopback_host(host) for host in hosts)
+        and getattr(http, "server_port", None) == upstream_port
     )
 
 

--- a/tests/test_http_config.py
+++ b/tests/test_http_config.py
@@ -72,6 +72,17 @@ def test_the_target_drops_what_home_assistant_records_about_a_config() -> None:
         ([], 8124, False),
         (None, 8124, False),
         (["127.0.0.1", "192.168.1.5"], 8124, False),
+        # Loopback-only, but not spelled exactly ["127.0.0.1"]. Each of these
+        # used to read as unaligned, so a reload moved an already-moved instance
+        # and restarted it -- every time, with nothing on the public port in
+        # between. They are aligned, and reload must treat them as such.
+        ("127.0.0.1", 8124, True),
+        (["::1"], 8124, True),
+        (["127.0.0.1", "::1"], 8124, True),
+        # A loopback-only instance is still not aligned on the wrong port.
+        ("127.0.0.1", 8123, False),
+        # Not loopback at all, whatever the spelling.
+        ("0.0.0.0", 8124, False),
     ],
     ids=[
         "where-we-want-it",
@@ -80,6 +91,11 @@ def test_the_target_drops_what_home_assistant_records_about_a_config() -> None:
         "listening-everywhere",
         "unset",
         "loopback-and-something-else",
+        "loopback-as-a-bare-string",
+        "ipv6-loopback",
+        "both-loopbacks",
+        "bare-string-wrong-port",
+        "bare-string-on-the-network",
     ],
 )
 async def test_alignment_is_read_from_the_running_server(
@@ -89,6 +105,11 @@ async def test_alignment_is_read_from_the_running_server(
 
     A staged config that failed its trial and reverted still sits in the store,
     so believing it would have the proxy report a boundary that is not there.
+
+    Alignment is "loopback only", not one exact spelling: Home Assistant can be
+    off the network on `::1`, and can hold the setting as a bare string or with
+    a second loopback entry. Reading any of those as unaligned made a reload
+    move and restart an instance that was already where it should be.
     """
     server = SimpleNamespace(server_host=host, server_port=port)
     with patch.object(hass, "http", server, create=True):

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,6 +1,7 @@
 """Tests for integration setup and the admin websocket API."""
 
 import socket
+from types import SimpleNamespace
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -373,6 +374,50 @@ async def test_the_move_is_confirmed_only_once_the_proxy_serves(
         assert await async_setup_entry(hass, entry)
         await hass.async_block_till_done()
         assert promote.called, "a proxy that answers must confirm the move"
+
+    await async_unload_entry(hass, entry)
+
+
+async def test_a_loopback_only_instance_is_not_moved_again_on_reload(
+    hass: HomeAssistant, socket_enabled: None
+) -> None:
+    """A reload of an already-moved instance must not move and restart it.
+
+    Home Assistant can report its loopback bind as a bare string rather than a
+    one-item list. That used to read as unaligned, so setting up again -- which
+    is half of a reload -- staged another move and restarted. After the restart
+    it still read as unaligned, so it restarted again: a loop that leaves the
+    instance unreachable until the box is power-cycled. Alignment now recognises
+    a loopback-only bind however it is spelled, so no move is staged.
+    """
+    for domain in ("http", "websocket_api", "api"):
+        await async_setup_component(hass, domain, {"http": {}})
+    await hass.async_block_till_done()
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            CONF_PROXY_PORT: _free_port(),
+            CONF_BIND_ADDRESS: "127.0.0.1",
+            CONF_UPSTREAM_HOST: "127.0.0.1",
+            CONF_UPSTREAM_PORT: 8123,
+            CONF_MANAGE_HTTP: True,
+        },
+    )
+    entry.add_to_hass(hass)
+
+    restarts: list[ServiceCall] = []
+    hass.services.async_register("homeassistant", "restart", restarts.append)
+
+    # Home Assistant is already loopback-only, but spelled as a bare string,
+    # which is exactly the representation that used to defeat alignment.
+    server = SimpleNamespace(server_host="127.0.0.1", server_port=8123)
+    with patch.object(hass, "http", server, create=True):
+        assert await async_setup_entry(hass, entry)
+        await hass.async_block_till_done()
+
+    assert not restarts, "an already-moved instance must not be moved again"
+    assert hass.data[DATA_RBAC].proxy is not None, "the proxy should just start"
 
     await async_unload_entry(hass, entry)
 


### PR DESCRIPTION
Fixes #23.

Reloading the integration on an already-moved instance could restart Home Assistant in a loop, leaving it unreachable until a power cycle.

is_aligned() required server_host to be exactly ["127.0.0.1"], so a loopback-only instance whose bind was held as a bare string, on IPv6 ::1, or with a second loopback entry read as unaligned -- so setup staged another move and restarted, repeatedly. Alignment now means loopback-only on the expected port, tolerating string-or-list and IPv6 loopback.

Verified the added tests fail on current code (the log shows the spurious "Moving Home Assistant ... restarting" on a reload) and pass with the fix.