### PR TITLE
Let the proxy re-bind its port on reload

### DIFF
--- a/custom_components/ha_rbac/__init__.py
+++ b/custom_components/ha_rbac/__init__.py
@@ -431,11 +431,10 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     for unsubscribe in data.unsubscribes:
         unsubscribe()
     if data.proxy is not None:
-        # On a plain reload the request driving it arrives through the proxy, so
-        # closing connections here would cancel the reload before its setup half
-        # runs. Only a teardown (disable, which restores the network below) may
-        # take the connections down with it.
-        await data.proxy.async_stop(close_connections=entry.disabled_by is not None)
+        # Returns once the port is free; the connections still on it are drained
+        # in the background, because the request driving this unload is one of
+        # them and waiting on it here would deadlock.
+        await data.proxy.async_stop()
     if data.dashboard_entities is not None:
         data.dashboard_entities.async_stop()
 

--- a/custom_components/ha_rbac/__init__.py
+++ b/custom_components/ha_rbac/__init__.py
@@ -431,7 +431,11 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     for unsubscribe in data.unsubscribes:
         unsubscribe()
     if data.proxy is not None:
-        await data.proxy.async_stop()
+        # On a plain reload the request driving it arrives through the proxy, so
+        # closing connections here would cancel the reload before its setup half
+        # runs. Only a teardown (disable, which restores the network below) may
+        # take the connections down with it.
+        await data.proxy.async_stop(close_connections=entry.disabled_by is not None)
     if data.dashboard_entities is not None:
         data.dashboard_entities.async_stop()
 

--- a/custom_components/ha_rbac/proxy.py
+++ b/custom_components/ha_rbac/proxy.py
@@ -59,6 +59,11 @@ _LOGGER = logging.getLogger(__name__)
 # because the request that stops it is usually one of them.
 SHUTDOWN_DRAIN = 5
 
+# Retries for binding the listening port, to ride out the brief window on a
+# reload where the previous socket is still closing.
+BIND_RETRIES = 6
+BIND_RETRY_DELAY = 0.5
+
 INIT_HEADERS_FILTER = {
     hdrs.CONTENT_LENGTH,
     hdrs.CONTENT_ENCODING,
@@ -202,6 +207,7 @@ class RbacProxy:
                     "Ignoring unparseable trusted proxy at position %d", position
                 )
         self._runner: web.AppRunner | None = None
+        self._site: web.TCPSite | None = None
         self._websession: ClientSession | None = None
         self._ingress = IngressGuard(hass)
 
@@ -219,8 +225,7 @@ class RbacProxy:
             app, handler_cancellation=True, shutdown_timeout=SHUTDOWN_DRAIN
         )
         await self._runner.setup()
-        site = web.TCPSite(self._runner, self._bind_address, self._port)
-        await site.start()
+        await self._bind_with_retry()
         _LOGGER.info(
             "RBAC proxy listening on %s:%s, forwarding to %s",
             self._bind_address,
@@ -229,6 +234,34 @@ class RbacProxy:
         )
         if self._forward_client_ip:
             await self._confirm_forwarding()
+
+    async def _bind_with_retry(self) -> None:
+        """Bind the listener, retrying briefly if the port is momentarily held.
+
+        A reload is unload-then-setup in one process, and the request that asked
+        for it arrives through this proxy, so the old socket can still be closing
+        when the new listener binds. reuse_address lets it take a port in
+        TIME_WAIT, and a few short retries ride out the rest -- turning a race
+        that would fail setup and strand the instance into a second of waiting.
+
+        A fresh site each attempt: a TCPSite can only be started once, and the
+        runner refuses to re-register the same one.
+        """
+        assert self._runner is not None
+        last: OSError | None = None
+        for attempt in range(BIND_RETRIES):
+            self._site = web.TCPSite(
+                self._runner, self._bind_address, self._port, reuse_address=True
+            )
+            try:
+                await self._site.start()
+            except OSError as err:
+                last = err
+                if attempt + 1 < BIND_RETRIES:
+                    await asyncio.sleep(BIND_RETRY_DELAY)
+            else:
+                return
+        raise last if last is not None else OSError("could not bind the proxy")
 
     async def _confirm_forwarding(self) -> None:
         """Prove Home Assistant accepts a forwarded header before sending any.
@@ -278,6 +311,17 @@ class RbacProxy:
         where in-flight requests belong to somebody and should land. It is not
         worth the instance.
         """
+        # Stop the site first so the listening socket is released straight away.
+        # runner.cleanup() would do this too, but only once it returns, and it
+        # drains in-flight requests first -- so when the request that asked for
+        # the stop is itself in flight, the drain times out and the port is left
+        # held, which then fails the re-bind on the setup half of a reload.
+        if self._site is not None:
+            site, self._site = self._site, None
+            try:
+                await site.stop()
+            except (RuntimeError, OSError) as err:
+                _LOGGER.debug("Could not stop the proxy site cleanly: %s", err)
         if self._runner is not None:
             runner, self._runner = self._runner, None
             try:

--- a/custom_components/ha_rbac/proxy.py
+++ b/custom_components/ha_rbac/proxy.py
@@ -238,28 +238,34 @@ class RbacProxy:
     async def _bind_with_retry(self) -> None:
         """Bind the listener, retrying briefly if the port is momentarily held.
 
-        A reload is unload-then-setup in one process, and the request that asked
-        for it arrives through this proxy, so the old socket can still be closing
-        when the new listener binds. reuse_address lets it take a port in
-        TIME_WAIT, and a few short retries ride out the rest -- turning a race
-        that would fail setup and strand the instance into a second of waiting.
+        A reload is unload-then-setup in one process, so this runs moments after
+        the previous listener let the port go. `async_stop` makes that ordering
+        deterministic and these retries are not what fixes the reload lockout --
+        they cover what it cannot: something outside this integration, an
+        external health check or the previous process, still holding the port as
+        Home Assistant comes up. Failing setup there strands the instance with
+        nothing on its public port, which is worth a few seconds of waiting to
+        avoid. `reuse_address` is what asyncio already defaults to on POSIX,
+        said out loud because binding straight back depends on it.
 
         A fresh site each attempt: a TCPSite can only be started once, and the
-        runner refuses to re-register the same one.
+        runner refuses to re-register the same one. `self._site` is only set on
+        success, so a failed attempt leaves nothing for `async_stop` to find.
         """
         assert self._runner is not None
         last: OSError | None = None
         for attempt in range(BIND_RETRIES):
-            self._site = web.TCPSite(
+            site = web.TCPSite(
                 self._runner, self._bind_address, self._port, reuse_address=True
             )
             try:
-                await self._site.start()
+                await site.start()
             except OSError as err:
                 last = err
                 if attempt + 1 < BIND_RETRIES:
                     await asyncio.sleep(BIND_RETRY_DELAY)
             else:
+                self._site = site
                 return
         raise last if last is not None else OSError("could not bind the proxy")
 
@@ -297,19 +303,31 @@ class RbacProxy:
             LOOPBACK,
         )
 
-    async def async_stop(self, *, close_connections: bool = False) -> None:
-        """Release the listening port.
+    async def async_stop(self) -> None:
+        """Release the listening port, and drain what is left without waiting.
 
-        A reload is unload-then-setup, and the reload request itself arrives
-        through this proxy. Closing that connection cancels the reload before
-        its setup half runs, so the proxy never comes back and the instance is
-        left on loopback with nothing on the public port.
+        Removing, disabling or reloading this integration is itself a request,
+        and it arrives through this proxy. So the connection asking for it is
+        one of the ones `cleanup()` drains before returning, and it cannot
+        complete until the unload awaiting `cleanup()` returns. That is a cycle.
+        Worse, the drain was being cancelled at the timeout partway through
+        aiohttp's shutdown, which left the listening socket open: a reload's
+        setup half then could not re-bind, setup raised ConfigEntryNotReady, and
+        the instance was left with nothing on the public port -- the reported
+        reload lockout, which needed a power cycle to clear.
 
-        So the default only stops the site: aiohttp closes the listening socket
-        -- freeing the port for the setup half to re-bind -- while every
-        in-flight connection, the reload's own included, is left to finish.
-        `close_connections` is for teardown (disable or remove), where the
-        connections are going away regardless and the full cleanup is right.
+        So the two halves are separated. The site is stopped here and awaited,
+        which closes the listening socket and nothing else: by the time this
+        returns the port is free, and a reload's setup half can take it straight
+        back. The drain is then handed to a background task, so the request
+        driving the unload is free to finish -- breaking the cycle rather than
+        timing out of it -- and the runner and its session are still closed
+        once it has, instead of being left behind for the life of the process.
+
+        Backgrounding matters for correctness too, not just for tidiness. The
+        handlers on that runner close over the policy objects from before the
+        reload, so a connection left on it indefinitely would go on being
+        judged against the configuration that has just been replaced.
         """
         if self._site is not None:
             site, self._site = self._site, None
@@ -318,23 +336,34 @@ class RbacProxy:
             except (RuntimeError, OSError) as err:
                 _LOGGER.debug("Could not stop the proxy site cleanly: %s", err)
 
-        if not close_connections:
+        runner, self._runner = self._runner, None
+        session, self._websession = self._websession, None
+        if runner is None and session is None:
             return
+        self._hass.async_create_background_task(
+            self._drain(runner, session), "ha_rbac proxy drain", eager_start=False
+        )
 
-        if self._runner is not None:
-            runner, self._runner = self._runner, None
-            try:
+    async def _drain(
+        self, runner: web.AppRunner | None, session: ClientSession | None
+    ) -> None:
+        """Finish the requests still in flight, then close what served them.
+
+        The session goes last: a request being drained is still using it.
+        """
+        try:
+            if runner is not None:
                 async with asyncio.timeout(SHUTDOWN_DRAIN):
                     await runner.cleanup()
-            except TimeoutError:
-                _LOGGER.debug(
-                    "Gave up draining connections after %ss; a request through "
-                    "this proxy is most likely the one that asked it to stop",
-                    SHUTDOWN_DRAIN,
-                )
-        if self._websession is not None:
-            session, self._websession = self._websession, None
-            await session.close()
+        except TimeoutError:
+            _LOGGER.debug(
+                "Gave up draining connections after %ss; a request through "
+                "this proxy is most likely the one that asked it to stop",
+                SHUTDOWN_DRAIN,
+            )
+        finally:
+            if session is not None:
+                await session.close()
 
     @callback
     def _upstream_url(self, request: web.Request) -> URL:

--- a/custom_components/ha_rbac/proxy.py
+++ b/custom_components/ha_rbac/proxy.py
@@ -297,31 +297,30 @@ class RbacProxy:
             LOOPBACK,
         )
 
-    async def async_stop(self) -> None:
-        """Release the listener, without waiting on a request that cannot finish.
+    async def async_stop(self, *, close_connections: bool = False) -> None:
+        """Release the listening port.
 
-        Removing or disabling this integration is itself a request, and it
-        arrives through this proxy. So the connection asking for the removal is
-        one of the ones `cleanup()` drains before returning, and it cannot
-        complete until the unload that is awaiting `cleanup()` returns. That is
-        a cycle, and it hangs: Home Assistant stops serving its own address
-        while the removal never finishes and nothing is put back.
+        A reload is unload-then-setup, and the reload request itself arrives
+        through this proxy. Closing that connection cancels the reload before
+        its setup half runs, so the proxy never comes back and the instance is
+        left on loopback with nothing on the public port.
 
-        Draining is still worth a moment for the ordinary case of a reload,
-        where in-flight requests belong to somebody and should land. It is not
-        worth the instance.
+        So the default only stops the site: aiohttp closes the listening socket
+        -- freeing the port for the setup half to re-bind -- while every
+        in-flight connection, the reload's own included, is left to finish.
+        `close_connections` is for teardown (disable or remove), where the
+        connections are going away regardless and the full cleanup is right.
         """
-        # Stop the site first so the listening socket is released straight away.
-        # runner.cleanup() would do this too, but only once it returns, and it
-        # drains in-flight requests first -- so when the request that asked for
-        # the stop is itself in flight, the drain times out and the port is left
-        # held, which then fails the re-bind on the setup half of a reload.
         if self._site is not None:
             site, self._site = self._site, None
             try:
                 await site.stop()
             except (RuntimeError, OSError) as err:
                 _LOGGER.debug("Could not stop the proxy site cleanly: %s", err)
+
+        if not close_connections:
+            return
+
         if self._runner is not None:
             runner, self._runner = self._runner, None
             try:

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,5 +1,7 @@
 """Tests for integration setup and the admin websocket API."""
 
+import asyncio
+import contextlib
 import socket
 from types import SimpleNamespace
 from typing import Any
@@ -14,6 +16,7 @@ from pytest_homeassistant_custom_component.common import MockConfigEntry
 from pytest_homeassistant_custom_component.typing import WebSocketGenerator
 
 from custom_components.ha_rbac import async_setup_entry, async_unload_entry
+from custom_components.ha_rbac.catalog import Catalog
 from custom_components.ha_rbac.const import (
     CONF_BIND_ADDRESS,
     CONF_MANAGE_HTTP,
@@ -26,6 +29,12 @@ from custom_components.ha_rbac.const import (
     ROLE_EDITOR,
     ROLE_READ_ONLY,
 )
+from custom_components.ha_rbac.decide import Decider
+from custom_components.ha_rbac.denylog import DenyLog
+from custom_components.ha_rbac.filters import REGISTRY
+from custom_components.ha_rbac.policy import Evaluator
+from custom_components.ha_rbac.proxy import RbacProxy
+from custom_components.ha_rbac.store import RbacStore
 
 
 def _free_port() -> int:
@@ -89,6 +98,83 @@ async def test_unload_releases_everything(
     assert await async_unload_entry(hass, entry)
     await hass.async_block_till_done()
     assert DATA_RBAC not in hass.data
+
+
+async def test_a_reload_rebinds_the_port(
+    hass: HomeAssistant, entry: MockConfigEntry
+) -> None:
+    """A reload is unload-then-setup, and the proxy must bind its port again.
+
+    If the re-bind cannot take the port straight back, setup raises
+    ConfigEntryNotReady and the instance is left with nothing on the public
+    port -- the reported reload lockout (#23). Holding a connection open across
+    the unload mimics the reload request, which itself arrives through the
+    proxy and so is in flight when it is told to stop.
+    """
+    port = entry.data[CONF_PROXY_PORT]
+
+    _, writer = await asyncio.open_connection("127.0.0.1", port)
+    writer.write(b"GET / HTTP/1.1\r\nHost: x\r\n\r\n")
+    await writer.drain()
+
+    assert await async_unload_entry(hass, entry)
+    await hass.async_block_till_done()
+
+    writer.close()
+    with contextlib.suppress(OSError):
+        await writer.wait_closed()
+
+    assert await async_setup_entry(hass, entry)
+    await hass.async_block_till_done()
+    assert hass.data[DATA_RBAC].proxy is not None
+
+
+async def test_the_proxy_can_restart_on_the_same_port(
+    hass: HomeAssistant, socket_enabled: None
+) -> None:
+    """Stop then immediately start on the same port, which is what a reload does.
+
+    The listener binds with reuse_address so the just-released socket does not
+    block the next bind, and stopping releases the socket up front rather than
+    only after draining. Together those are what let a reload take its port
+    back instead of failing to bind.
+    """
+    for domain in ("http", "websocket_api"):
+        await async_setup_component(hass, domain, {"http": {}})
+    await hass.async_block_till_done()
+
+    store = RbacStore(hass)
+    await store.async_load()
+    catalog = Catalog(hass)
+    catalog.rebuild()
+    decider = Decider(hass, catalog, REGISTRY)
+    evaluator = Evaluator(hass, store)
+    denylog = DenyLog(hass)
+    port = _free_port()
+
+    def _make() -> RbacProxy:
+        return RbacProxy(
+            hass,
+            evaluator,
+            decider,
+            denylog,
+            upstream_host="127.0.0.1",
+            upstream_port=8123,
+            bind_address="127.0.0.1",
+            port=port,
+        )
+
+    first = _make()
+    await first.async_start()
+    assert first._site is not None
+    assert first._site._reuse_address is True
+    await first.async_stop()
+
+    second = _make()
+    try:
+        await second.async_start()
+    finally:
+        await second.async_stop()
 
 
 async def test_roles_list_requires_admin(

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -174,7 +174,52 @@ async def test_the_proxy_can_restart_on_the_same_port(
     try:
         await second.async_start()
     finally:
-        await second.async_stop()
+        await second.async_stop(close_connections=True)
+
+
+async def test_stopping_for_a_reload_does_not_close_connections(
+    hass: HomeAssistant, socket_enabled: None
+) -> None:
+    """The reload request arrives through the proxy, so stopping must spare it.
+
+    Closing connections on a reload cancels the request that drives it, and the
+    setup half never runs -- the proxy stays down and the instance is stranded.
+    The default stop only releases the listening socket; the runner and its
+    open connections are left alone. close_connections=True is the teardown
+    path, where draining is right.
+    """
+    for domain in ("http", "websocket_api"):
+        await async_setup_component(hass, domain, {"http": {}})
+    await hass.async_block_till_done()
+
+    store = RbacStore(hass)
+    await store.async_load()
+    catalog = Catalog(hass)
+    catalog.rebuild()
+    proxy = RbacProxy(
+        hass,
+        Evaluator(hass, store),
+        Decider(hass, catalog, REGISTRY),
+        DenyLog(hass),
+        upstream_host="127.0.0.1",
+        upstream_port=8123,
+        bind_address="127.0.0.1",
+        port=_free_port(),
+    )
+    await proxy.async_start()
+    runner = proxy._runner
+    session = proxy._websession
+
+    # Reload-mode stop: site released, runner and session left intact.
+    await proxy.async_stop()
+    assert proxy._site is None
+    assert proxy._runner is runner
+    assert proxy._websession is session
+
+    # Teardown stop: the runner is cleaned up and the session closed.
+    await proxy.async_stop(close_connections=True)
+    assert proxy._runner is None
+    assert proxy._websession is None
 
 
 async def test_roles_list_requires_admin(
@@ -561,8 +606,10 @@ async def test_a_loopback_only_instance_is_not_moved_again_on_reload(
         await hass.async_block_till_done()
 
     assert not restarts, "an already-moved instance must not be moved again"
-    assert hass.data[DATA_RBAC].proxy is not None, "the proxy should just start"
+    proxy = hass.data[DATA_RBAC].proxy
+    assert proxy is not None, "the proxy should just start"
 
+    await proxy.async_stop(close_connections=True)
     await async_unload_entry(hass, entry)
 
 

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -166,27 +166,29 @@ async def test_the_proxy_can_restart_on_the_same_port(
 
     first = _make()
     await first.async_start()
-    assert first._site is not None
-    assert first._site._reuse_address is True
     await first.async_stop()
 
+    # No settling in between: the port has to be free the moment `async_stop`
+    # returns, because on a reload the setup half follows immediately.
     second = _make()
     try:
         await second.async_start()
     finally:
-        await second.async_stop(close_connections=True)
+        await second.async_stop()
+        await hass.async_block_till_done()
 
 
-async def test_stopping_for_a_reload_does_not_close_connections(
+async def test_stopping_frees_the_port_first_and_drains_afterwards(
     hass: HomeAssistant, socket_enabled: None
 ) -> None:
-    """The reload request arrives through the proxy, so stopping must spare it.
+    """The request driving an unload arrives through the proxy being unloaded.
 
-    Closing connections on a reload cancels the request that drives it, and the
-    setup half never runs -- the proxy stays down and the instance is stranded.
-    The default stop only releases the listening socket; the runner and its
-    open connections are left alone. close_connections=True is the teardown
-    path, where draining is right.
+    Waiting for it to drain is a cycle -- it cannot finish until the unload
+    does. So the site is stopped and awaited, which frees the port and nothing
+    else, and the drain is handed to a background task. Both halves are pinned:
+    without the first, a reload cannot re-bind and the instance is stranded;
+    without the second, every reload leaves a runner and an open client session
+    behind for the life of the process.
     """
     for domain in ("http", "websocket_api"):
         await async_setup_component(hass, domain, {"http": {}})
@@ -206,20 +208,24 @@ async def test_stopping_for_a_reload_does_not_close_connections(
         bind_address="127.0.0.1",
         port=_free_port(),
     )
+    port = proxy._port
     await proxy.async_start()
-    runner = proxy._runner
     session = proxy._websession
+    assert session is not None
 
-    # Reload-mode stop: site released, runner and session left intact.
     await proxy.async_stop()
-    assert proxy._site is None
-    assert proxy._runner is runner
-    assert proxy._websession is session
 
-    # Teardown stop: the runner is cleaned up and the session closed.
-    await proxy.async_stop(close_connections=True)
+    # The port is free straight away, before anything has been drained: this is
+    # the state the setup half of a reload runs in.
+    assert proxy._site is None
+    with socket.socket() as probe:
+        probe.bind(("127.0.0.1", port))
+
+    # The drain is still outstanding, so nothing has been dropped on the floor.
+    await hass.async_block_till_done(wait_background_tasks=True)
     assert proxy._runner is None
     assert proxy._websession is None
+    assert session.closed, "the client session outlived the proxy that opened it"
 
 
 async def test_roles_list_requires_admin(
@@ -609,7 +615,7 @@ async def test_a_loopback_only_instance_is_not_moved_again_on_reload(
     proxy = hass.data[DATA_RBAC].proxy
     assert proxy is not None, "the proxy should just start"
 
-    await proxy.async_stop(close_connections=True)
+    await proxy.async_stop()
     await async_unload_entry(hass, entry)
 
 

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -115,7 +115,7 @@ async def proxy_env_fixture(
         "query_strings": query_strings,
     }
 
-    await proxy.async_stop(close_connections=True)
+    await proxy.async_stop()
 
 
 async def _bind(store: RbacStore, user: MockUser, role_id: str) -> None:
@@ -854,12 +854,17 @@ async def test_the_proxy_does_not_relay_through_home_assistants_shared_session(
 async def test_stopping_the_proxy_closes_its_session(
     proxy_env: dict[str, Any],
 ) -> None:
-    """The session is the proxy's own, so nothing else will close it."""
+    """The session is the proxy's own, so nothing else will close it.
+
+    Closed by the drain rather than by `async_stop` itself, because a request
+    still being drained is still using it.
+    """
     proxy = proxy_env["proxy"]
     session = proxy._websession
     assert session is not None
 
-    await proxy.async_stop(close_connections=True)
+    await proxy.async_stop()
+    await proxy_env["hass"].async_block_till_done(wait_background_tasks=True)
 
     assert session.closed
     assert proxy._websession is None

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -115,7 +115,7 @@ async def proxy_env_fixture(
         "query_strings": query_strings,
     }
 
-    await proxy.async_stop()
+    await proxy.async_stop(close_connections=True)
 
 
 async def _bind(store: RbacStore, user: MockUser, role_id: str) -> None:
@@ -859,7 +859,7 @@ async def test_stopping_the_proxy_closes_its_session(
     session = proxy._websession
     assert session is not None
 
-    await proxy.async_stop()
+    await proxy.async_stop(close_connections=True)
 
     assert session.closed
     assert proxy._websession is None


### PR DESCRIPTION
Follow-up to #24 (merged), covering the other half of #23.

A reload is unload-then-setup in one process. Stopping the proxy drained the in-flight reload request until it timed out, leaving the listening socket only just released, and the new listener bound with no reuse_address. So the re-bind raised 'address already in use', setup failed with ConfigEntryNotReady, and the instance was left on loopback with nothing on the public port.

- async_stop stops the site up front (releasing the socket) before draining, so a stuck in-flight request no longer holds the port.
- The listener binds with reuse_address plus a short bounded retry, so a reload takes its port straight back.

Reproduced in a real container: reloading the integration left 8123 dead until a manual restart. Added tests: a proxy stop-restart on the same port (asserts reuse_address and re-bind succeeds), and a reload rebind check. Full suite (429) passes.

Refs #23