### PR TITLE
Confirm before deleting a role

### DIFF
--- a/custom_components/ha_rbac/frontend/ha-rbac-panel.js
+++ b/custom_components/ha_rbac/frontend/ha-rbac-panel.js
@@ -1942,6 +1942,16 @@ class HaRbacPanel extends HTMLElement {
   }
 
   _deleteRole() {
+    const role = this._roles.find((r) => r.id === this._selected);
+    const name = role ? role.name : this._selected;
+    if (
+      !window.confirm(
+        `Delete the role "${name}"? Anyone who had it falls back to their ` +
+          `Home Assistant group. This cannot be undone.`,
+      )
+    ) {
+      return;
+    }
     this._guard(async () => {
       await this._call("roles/delete", { role_id: this._selected });
       this._selected = null;

--- a/tests/test_frontend.py
+++ b/tests/test_frontend.py
@@ -56,3 +56,18 @@ def test_every_element_the_panel_looks_up_is_one_it_renders() -> None:
     assert looked_up <= rendered, (
         f"looked up but never rendered: {looked_up - rendered}"
     )
+
+
+def test_deleting_a_role_asks_first() -> None:
+    """Delete is the one button in the panel that cannot be taken back.
+
+    Its holders fall back to their Home Assistant group the moment it lands, so
+    a misplaced click hands someone the whole instance. Every other action here
+    is editable afterwards, which is why this is the only one pinned: the
+    confirmation is easy to drop in a refactor and nothing else would notice.
+    """
+    source = PANEL.read_text()
+    start = source.index("  _deleteRole() {")
+    body = source[start : source.index('"roles/delete"', start)]
+
+    assert "confirm(" in body, "_deleteRole must confirm before it calls the API"


### PR DESCRIPTION
Deleting a role is destructive -- its holders fall back to their Home Assistant group -- but the Delete button did it on the first click with no confirmation.

Adds a confirmation dialog that names the role and warns it cannot be undone; cancelling leaves the role untouched. JS parses (node --check) and the frontend static-check tests pass.