### PR TITLE
Fix denials/recent returning everything when limit is 0

### DIFF
--- a/custom_components/ha_rbac/denylog.py
+++ b/custom_components/ha_rbac/denylog.py
@@ -46,7 +46,15 @@ class DenyLog:
 
     @callback
     def async_recent(self, limit: int = 100) -> list[dict[str, Any]]:
-        """Return the most recent denials, newest first."""
+        """Return the most recent denials, newest first.
+
+        `[-limit:]` means "the whole list" when `limit` is 0, not "none of
+        it" -- Python's slice syntax has no way to ask for zero from the end
+        the way it can ask for zero from the start. Guarded explicitly so a
+        caller asking for zero denials gets zero rather than all of them.
+        """
+        if limit <= 0:
+            return []
         return [asdict(entry) for entry in list(self._entries)[-limit:][::-1]]
 
     @callback

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -130,3 +130,23 @@ async def test_denylog_returns_newest_first(hass: HomeAssistant) -> None:
         "cmd1",
         "cmd0",
     ]
+
+
+@pytest.mark.parametrize("limit", [0, -1], ids=["zero", "negative"])
+async def test_asking_for_no_denials_returns_none_of_them(
+    hass: HomeAssistant, limit: int
+) -> None:
+    """`[-limit:]` reads as the whole list when limit is 0, not as none of it.
+
+    Python's slice syntax has no way to ask for zero from the end the way
+    `[:0]` asks for zero from the start, so the guard has to be explicit. The
+    websocket schema takes `limit` as a plain int with no range, so zero is a
+    value that reaches this. A negative goes the same way: `[5:]` would drop
+    the oldest five and return everything after them.
+    """
+    log = DenyLog(hass)
+    for index in range(3):
+        log.async_record(Denial("u1", "Guest", "ws", f"cmd{index}", "tier", []))
+    assert log.async_recent() != [], "precondition: there are denials to withhold"
+
+    assert log.async_recent(limit) == []


### PR DESCRIPTION
`list(self._entries)[-limit:]` means "the whole list" when `limit` is 0,
not "none of it" — Python slicing has no way to spell "zero from the end"
the way `[:0]` spells "zero from the start". A caller asking
`denials/recent` with `limit=0` got up to `DENYLOG_SIZE` (500) entries
back instead of none.

This is an admin-only surface (`@websocket_api.require_admin`), so impact
is low on its own, but it's a plain logic inversion worth closing —
`vol.Optional("limit", default=100): int` has no range constraint, so 0
is a value that can actually reach this code.