### PR TITLE
Recorded apps weren't actually granted once a role held an allow list

### DIFF
--- a/custom_components/ha_rbac/frontend/ha-rbac-panel.js
+++ b/custom_components/ha_rbac/frontend/ha-rbac-panel.js
@@ -1085,6 +1085,18 @@ class HaRbacPanel extends HTMLElement {
             ` but a deny rule on this role still overrules ${one ? "it" : "them"}:` +
             ` ${named}${rest > 0 ? ` and ${rest} more` : ""}.`;
         }
+        // The same for screens. Granting an app only ever grows this role's own
+        // allow list, so a denial on it still wins, and a sidebar that is still
+        // missing the screen is a worse way to find that out.
+        const blockedApps = result.blocked_apps || [];
+        if (blockedApps.length) {
+          const one = blockedApps.length === 1;
+          message +=
+            ` ${one ? "One screen is" : `${blockedApps.length} screens are`}` +
+            ` still denied by a rule on this role:` +
+            ` ${blockedApps.slice(0, 5).join(", ")}` +
+            `${blockedApps.length > 5 ? ` and ${blockedApps.length - 5} more` : ""}.`;
+        }
       },
       () => message
     );

--- a/custom_components/ha_rbac/record.py
+++ b/custom_components/ha_rbac/record.py
@@ -146,12 +146,20 @@ def apply(role: dict[str, object], recording: Recording) -> dict[str, object]:
 
     if recording.apps:
         apps = dict(role.get("apps") or {})
-        # Apps are held as a denial list, so granting one is removing it.
+        # Apps are held as a denial list, so granting one is usually just
+        # removing it. But once a role also holds an allow whitelist,
+        # app_allowed() requires an explicit match against *that* list --
+        # removing a denial does nothing for an app the whitelist never
+        # named. An empty allow list means "everything not denied" and has
+        # to stay empty rather than being narrowed to only what was seen.
         apps["deny"] = [
             url_path
             for url_path in (apps.get("deny") or [])
             if url_path not in recording.apps
         ]
+        existing_allow = apps.get("allow") or []
+        if existing_allow:
+            apps["allow"] = sorted(set(existing_allow) | recording.apps)
         changes["apps"] = apps
 
     if recording.capabilities:
@@ -188,6 +196,14 @@ def _merged_entities(role: dict[str, object], recording: Recording) -> dict[str,
     return allow
 
 
+def _permissions_for(hass: HomeAssistant, role: dict[str, object]) -> Permissions:
+    """Compile a role the way still_blocked/blocked_apps need to check it."""
+    compiled = compile_role(
+        hass, role, PermissionLookup(er.async_get(hass), dr.async_get(hass))
+    )
+    return Permissions(roles=[compiled])
+
+
 @callback
 def still_blocked(
     hass: HomeAssistant, role: dict[str, object], recording: Recording
@@ -200,12 +216,26 @@ def still_blocked(
     quietly undoing a decision somebody made on purpose, which is worse -- so
     it is reported and left to them.
     """
-    compiled = compile_role(
-        hass, role, PermissionLookup(er.async_get(hass), dr.async_get(hass))
-    )
-    permissions = Permissions(roles=[compiled])
+    permissions = _permissions_for(hass, role)
     return sorted(
         entity_id
         for entity_id, key in recording.entities.items()
         if not permissions.check_entity(entity_id, key)
+    )
+
+
+@callback
+def blocked_apps(
+    hass: HomeAssistant, role: dict[str, object], recording: Recording
+) -> list[str]:
+    """Return the recorded apps the role still cannot open, after applying.
+
+    Same reasoning as still_blocked, and for the same reason it cannot be
+    folded into that check: apply() only ever grows a role's own apps.allow,
+    so a deny elsewhere in the role, or an allow list left empty on purpose,
+    can still refuse an app that was just recorded.
+    """
+    permissions = _permissions_for(hass, role)
+    return sorted(
+        url_path for url_path in recording.apps if not permissions.app_allowed(url_path)
     )

--- a/custom_components/ha_rbac/websocket_api.py
+++ b/custom_components/ha_rbac/websocket_api.py
@@ -415,6 +415,7 @@ async def handle_record_stop(
             # the role vetoes it. Saying which ones beats leaving someone to
             # find out from a broken dashboard.
             "blocked": record.still_blocked(hass, updated, recording),
+            "blocked_apps": record.blocked_apps(hass, updated, recording),
         },
     )
 

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -320,12 +320,17 @@ async def test_stopping_a_recording_reports_everything_it_saw(
     """
     data = hass.data[DATA_RBAC]
     role = await data.store.async_create_role(
-        {"name": "Guests", "deny": {CAT_ENTITIES: {"domains": {"lock": True}}}}
+        {
+            "name": "Guests",
+            "deny": {CAT_ENTITIES: {"domains": {"lock": True}}},
+            "apps": {"allow": [], "deny": ["config/*"], "dashboards": {}},
+        }
     )
     recording = data.recorder.start(role["id"])
     recording.note_entity("light.kitchen", POLICY_READ)
     recording.note_entity("lock.front", POLICY_READ)
     recording.apps.add("lovelace")
+    recording.apps.add("config/automation")
     recording.capabilities.add("automations")
 
     client = await hass_ws_client(hass)
@@ -339,10 +344,12 @@ async def test_stopping_a_recording_reports_everything_it_saw(
         "light.kitchen": POLICY_READ,
         "lock.front": POLICY_READ,
     }
-    assert result["seen"]["apps"] == ["lovelace"]
+    assert result["seen"]["apps"] == ["config/automation", "lovelace"]
     assert result["seen"]["capabilities"] == ["automations"]
-    # Added to the allow side, and vetoed by the role's own denial.
+    # Added to the allow side, and vetoed by the role's own denial. Both kinds
+    # are reported: an entity the deny rule overrules, and a screen it does.
     assert result["blocked"] == ["lock.front"]
+    assert result["blocked_apps"] == ["config/automation"]
 
 
 async def test_discarding_a_recording_leaves_the_role_alone(

--- a/tests/test_record.py
+++ b/tests/test_record.py
@@ -408,3 +408,75 @@ async def test_a_recorded_script_press_writes_the_script_down(
 
     assert decision.allowed is True
     assert recording.entities == {"script.night_lights": POLICY_CONTROL}
+
+
+async def test_a_recorded_app_is_granted_through_an_allow_list(
+    hass: HomeAssistant,
+) -> None:
+    """Removing a denial grants nothing while an allow whitelist is in force.
+
+    `app_allowed` takes denials first, then, if any role carries a non-empty
+    allow list, requires an explicit match against it. So on a role holding
+    one, dropping an app from `deny` leaves it just as unreachable -- the
+    whitelist never named it. The recording reported success and the app was
+    still missing from the sidebar.
+    """
+    role = {
+        "id": "guests",
+        "name": "Guests",
+        "apps": {"allow": ["lovelace"], "deny": ["energy"], "dashboards": {}},
+    }
+    recording = record.Recording(role_id="guests", started=None)
+    recording.apps.add("energy")
+
+    changes = record.apply(role, recording)
+
+    assert changes["apps"]["deny"] == [], "no longer denied"
+    assert changes["apps"]["allow"] == ["energy", "lovelace"], "and now named"
+
+    permissions = _permissions(hass, {**role, **changes})
+    assert permissions.app_allowed("energy") is True
+    assert permissions.app_allowed("history") is False, "the list still bounds"
+
+
+async def test_an_empty_allow_list_is_left_empty(hass: HomeAssistant) -> None:
+    """Empty means "everything not denied", not "nothing yet".
+
+    Filling it with only what a recording happened to see would take away
+    every app the role could already open -- a recording only ever adds.
+    """
+    role = {
+        "id": "guests",
+        "name": "Guests",
+        "apps": {"allow": [], "deny": ["energy"], "dashboards": {}},
+    }
+    recording = record.Recording(role_id="guests", started=None)
+    recording.apps.add("energy")
+
+    changes = record.apply(role, recording)
+
+    assert changes["apps"]["allow"] == []
+    permissions = _permissions(hass, {**role, **changes})
+    assert permissions.app_allowed("energy") is True
+    assert permissions.app_allowed("history") is True, "and everything else still is"
+
+
+async def test_an_app_a_denial_still_refuses_is_reported(hass: HomeAssistant) -> None:
+    """`apply` only ever grows the role's own allow list, so a deny can win.
+
+    Same reasoning as the entity side: the denial is somebody's decision and
+    is not undone on their behalf, so it is reported instead of left to be
+    discovered from a sidebar that is still missing the screen.
+    """
+    role = {
+        "id": "guests",
+        "name": "Guests",
+        "apps": {"allow": [], "deny": ["config/*"], "dashboards": {}},
+    }
+    recording = record.Recording(role_id="guests", started=None)
+    recording.apps.add("config/automation")
+    recording.apps.add("energy")
+
+    updated = {**role, **record.apply(role, recording)}
+
+    assert record.blocked_apps(hass, updated, recording) == ["config/automation"]


### PR DESCRIPTION
`record.apply()` only ever removed a recorded app from a role's
`apps.deny`. That's enough while the role has no `apps.allow`, since
`app_allowed()` then permits anything not denied — but once a role also
holds a non-empty `apps.allow` whitelist, `app_allowed()` requires an
explicit match against *that* list, and removing a denial does nothing
for an app the whitelist never named. `record/stop` with `apply=True`
reported `"applied": true` and a `"blocked"` list that only ever covered
entities, so an admin had no way to learn the recorded app still wasn't
reachable.

`apply()` now also adds a recorded app to an existing, non-empty
`apps.allow` (an empty list is left alone — it means "everything not
denied," not "nothing yet"). A new `blocked_apps()` mirrors
`still_blocked()`'s reasoning for entities: even after applying, a deny
elsewhere in the role can still veto a just-recorded app, so it's
reported rather than silently left broken. Wired into `record/stop`'s
response as a new `"blocked_apps"` key alongside the existing
`"blocked"`.

Note: I couldn't run the pinned test suite in this environment
(`pytest-homeassistant-custom-component==0.13.357` requires Python
≥3.14, unavailable here) — checked the change against every existing
`test_record.py` case by hand (in particular the empty-`apps.allow`
cases, which are untouched by this change) and validated with
`ruff`/`py_compile`, but CI is the real gate here.