### PR TITLE
Reject roles/create when the id collides with an existing custom role

### DIFF
--- a/custom_components/ha_rbac/store.py
+++ b/custom_components/ha_rbac/store.py
@@ -95,13 +95,14 @@ class RbacStore:
         role.setdefault("id", uuid.uuid4().hex)
         role["system_generated"] = False
         validated = ROLE_SCHEMA(role)
-        existing = self.roles.get(validated["id"])
-        if existing is not None and existing.get("system_generated"):
-            # It would replace the predefined role in memory but is never
-            # persisted, so a restart would silently undo it.
-            raise ValueError(
-                f"{validated['id']} is a predefined role and cannot be replaced"
-            )
+        if validated["id"] in self.roles:
+            # A client-supplied id colliding with an existing role -- system
+            # or custom -- is not a create, it is a replace: every allow/deny
+            # rule the existing role had, and every user bound to it, would
+            # change out from under them with no confirmation. Editing an
+            # existing role goes through async_update_role instead, which the
+            # caller has to reach deliberately.
+            raise ValueError(f"a role with id {validated['id']!r} already exists")
         self.roles[validated["id"]] = validated
         await self._async_save()
         return validated

--- a/custom_components/ha_rbac/store.py
+++ b/custom_components/ha_rbac/store.py
@@ -95,13 +95,20 @@ class RbacStore:
         role.setdefault("id", uuid.uuid4().hex)
         role["system_generated"] = False
         validated = ROLE_SCHEMA(role)
-        if validated["id"] in self.roles:
-            # A client-supplied id colliding with an existing role -- system
-            # or custom -- is not a create, it is a replace: every allow/deny
-            # rule the existing role had, and every user bound to it, would
-            # change out from under them with no confirmation. Editing an
-            # existing role goes through async_update_role instead, which the
-            # caller has to reach deliberately.
+        existing = self.roles.get(validated["id"])
+        if existing is not None and existing.get("system_generated"):
+            # It would replace the predefined role in memory but is never
+            # persisted, so a restart would silently undo it.
+            raise ValueError(
+                f"{validated['id']} is a predefined role and cannot be replaced"
+            )
+        if existing is not None:
+            # A client-supplied id colliding with an existing *custom* role is
+            # not a create, it is a replace: every allow/deny rule the
+            # existing role had, and every user bound to it, would change out
+            # from under them with no confirmation. Editing an existing role
+            # goes through async_update_role instead, which the caller has to
+            # reach deliberately.
             raise ValueError(f"a role with id {validated['id']!r} already exists")
         self.roles[validated["id"]] = validated
         await self._async_save()

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -87,6 +87,34 @@ async def test_only_custom_roles_are_persisted(
     assert reloaded.roles[ROLE_ADMIN]["name"] == "Administrator"
 
 
+async def test_creating_a_role_never_replaces_an_existing_one(
+    store: RbacStore,
+) -> None:
+    """`roles/create` takes an unconstrained dict, so the id is the caller's.
+
+    An id matching an existing custom role used to be accepted and overwrite
+    that role outright -- allow, deny, tiers, apps -- with no error and nothing
+    to say a replace had happened instead of a create. Everyone bound to it
+    would get whatever the new definition said, wider or narrower. A retried
+    request or two admin tabs are enough to do it by accident.
+
+    Editing has its own deliberate path in `async_update_role`, so this one
+    only ever creates. The existing role is left exactly as it was.
+    """
+    original = await store.async_create_role(
+        {
+            "id": "guests",
+            "name": "Guests",
+            "deny": {"entities": {"domains": {"lock": True}}},
+        }
+    )
+
+    with pytest.raises(ValueError, match="already exists"):
+        await store.async_create_role({"id": "guests", "name": "Impostor"})
+
+    assert store.roles["guests"] == original
+
+
 async def test_store_notifies_listeners_on_write(store: RbacStore) -> None:
     """Compiled policies must be dropped when stored data changes."""
     calls: list[int] = []


### PR DESCRIPTION
`RbacStore.async_create_role` only refused a collision with a
*predefined* role's id. A client-supplied `id` matching an existing
*custom* role was accepted and silently replaced that role's entire
definition — allow/deny, tiers, apps, everything — with no error and no
confirmation. `msg["role"]` in `roles/create` is an unconstrained `dict`,
so the `id` field is fully client-controlled (a retried request, two
racing admin sessions, or a typo matching an existing custom role's id
would all trigger this).

Every user bound to that role id would get whatever the new definition
says — wider or narrower — without anyone being told a replace happened
instead of a create. Editing an existing role already has its own
explicit, deliberate path (`async_update_role`); creating one should only
ever create.