### PR TITLE
Reject proxy/upstream port collisions in the reconfigure flow too

### DIFF
--- a/custom_components/ha_rbac/config_flow.py
+++ b/custom_components/ha_rbac/config_flow.py
@@ -227,21 +227,30 @@ class RbacOptionsFlow(OptionsFlow):
         the case where nothing bridges the network is shown in the panel, which
         is the surface this integration is actually administered from.
         """
+        errors: dict[str, str] = {}
         if user_input is not None:
-            return self.async_create_entry(
-                data={
-                    CONF_PROXY_PORT: int(user_input[CONF_PROXY_PORT]),
-                    CONF_BIND_ADDRESS: user_input[CONF_BIND_ADDRESS],
-                    CONF_UPSTREAM_HOST: user_input[CONF_UPSTREAM_HOST],
-                    CONF_UPSTREAM_PORT: int(user_input[CONF_UPSTREAM_PORT]),
-                    CONF_MANAGE_HTTP: user_input.get(CONF_MANAGE_HTTP, False),
-                    CONF_RESTORE_ON_REMOVAL: user_input.get(
-                        CONF_RESTORE_ON_REMOVAL, DEFAULT_RESTORE_ON_REMOVAL
-                    ),
-                }
-            )
+            proxy_port = int(user_input[CONF_PROXY_PORT])
+            upstream_port = int(user_input[CONF_UPSTREAM_PORT])
+            if proxy_port == upstream_port:
+                # The initial setup refuses this combination outright; letting
+                # it back in here would bind the proxy where Home Assistant
+                # already answers.
+                errors[CONF_PROXY_PORT] = "port_conflict"
+            else:
+                return self.async_create_entry(
+                    data={
+                        CONF_PROXY_PORT: proxy_port,
+                        CONF_BIND_ADDRESS: user_input[CONF_BIND_ADDRESS],
+                        CONF_UPSTREAM_HOST: user_input[CONF_UPSTREAM_HOST],
+                        CONF_UPSTREAM_PORT: upstream_port,
+                        CONF_MANAGE_HTTP: user_input.get(CONF_MANAGE_HTTP, False),
+                        CONF_RESTORE_ON_REMOVAL: user_input.get(
+                            CONF_RESTORE_ON_REMOVAL, DEFAULT_RESTORE_ON_REMOVAL
+                        ),
+                    }
+                )
 
-        current = {**self.config_entry.data, **self.config_entry.options}
+        current = {**self.config_entry.data, **self.config_entry.options, **(user_input or {})}
         return self.async_show_form(
             step_id="init",
             data_schema=_schema(
@@ -250,4 +259,5 @@ class RbacOptionsFlow(OptionsFlow):
                 # Only worth asking where there is something to put back.
                 moved=bool(self.config_entry.data.get(DATA_PREVIOUS_HTTP)),
             ),
+            errors=errors,
         )

--- a/custom_components/ha_rbac/config_flow.py
+++ b/custom_components/ha_rbac/config_flow.py
@@ -250,7 +250,11 @@ class RbacOptionsFlow(OptionsFlow):
                     }
                 )
 
-        current = {**self.config_entry.data, **self.config_entry.options, **(user_input or {})}
+        current = {
+            **self.config_entry.data,
+            **self.config_entry.options,
+            **(user_input or {}),
+        }
         return self.async_show_form(
             step_id="init",
             data_schema=_schema(

--- a/custom_components/ha_rbac/strings.json
+++ b/custom_components/ha_rbac/strings.json
@@ -36,6 +36,9 @@
     }
   },
   "options": {
+    "error": {
+      "port_conflict": "The proxy cannot listen on the same port as Home Assistant."
+    },
     "step": {
       "init": {
         "title": "RBAC access control",

--- a/custom_components/ha_rbac/translations/en.json
+++ b/custom_components/ha_rbac/translations/en.json
@@ -36,6 +36,9 @@
     }
   },
   "options": {
+    "error": {
+      "port_conflict": "The proxy cannot listen on the same port as Home Assistant."
+    },
     "step": {
       "init": {
         "title": "RBAC access control",

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -13,8 +13,9 @@ import pytest
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType
 from homeassistant.setup import async_setup_component
+from pytest_homeassistant_custom_component.common import MockConfigEntry
 
-from custom_components.ha_rbac.config_flow import RbacConfigFlow
+from custom_components.ha_rbac.config_flow import RbacConfigFlow, RbacOptionsFlow
 from custom_components.ha_rbac.const import (
     CONF_BIND_ADDRESS,
     CONF_MANAGE_HTTP,
@@ -189,3 +190,61 @@ async def test_the_manual_instruction_survives_where_it_is_the_only_route(
     warning = step["description_placeholders"]["warning"]
     assert "127.0.0.1" in warning
     assert "Settings > System > Network" in warning
+
+
+@pytest.fixture(name="options")
+async def options_fixture(hass: HomeAssistant) -> RbacOptionsFlow:
+    """Return a reconfigure flow bound to an existing entry."""
+    await async_setup_component(hass, "http", {"http": {}})
+    entry = MockConfigEntry(domain=DOMAIN, data=PORTS)
+    entry.add_to_hass(hass)
+
+    handler = RbacOptionsFlow()
+    handler.hass = hass
+    # For an options flow `handler` is the config entry id, which is how
+    # `config_entry` finds the entry being reconfigured.
+    handler.handler = entry.entry_id
+    handler.flow_id = "test-options"
+    handler.context = {}
+    return handler
+
+
+async def test_reconfiguring_onto_one_port_is_refused_too(
+    options: RbacOptionsFlow,
+) -> None:
+    """One process cannot bind both, so the wizard refuses it -- and so must this.
+
+    The check existed only on the initial setup, so the same combination could
+    be reached later by reopening the options and typing it in. It saved, and
+    the failure arrived as a bind error on the next reload with the instance
+    already down.
+    """
+    step = await options.async_step_init({**PORTS, CONF_UPSTREAM_PORT: 8123})
+
+    assert step["type"] is FlowResultType.FORM
+    assert step["errors"] == {CONF_PROXY_PORT: "port_conflict"}
+
+
+async def test_a_refused_reconfigure_keeps_what_was_typed(
+    options: RbacOptionsFlow,
+) -> None:
+    """Resetting the form to the saved values loses the rest of the edit.
+
+    Somebody correcting one field should not have to retype the others they
+    changed in the same visit.
+    """
+    step = await options.async_step_init(
+        {**PORTS, CONF_UPSTREAM_PORT: 8123, CONF_BIND_ADDRESS: "127.0.0.1"}
+    )
+
+    defaults = {key.schema: key.default() for key in step["data_schema"].schema}
+    assert defaults[CONF_BIND_ADDRESS] == "127.0.0.1"
+
+
+async def test_a_valid_reconfigure_is_saved(options: RbacOptionsFlow) -> None:
+    """The refusal must not stand in the way of an ordinary change."""
+    step = await options.async_step_init({**PORTS, CONF_PROXY_PORT: 9000})
+
+    assert step["type"] is FlowResultType.CREATE_ENTRY
+    assert step["data"][CONF_PROXY_PORT] == 9000
+    assert step["data"][CONF_UPSTREAM_PORT] == PORTS[CONF_UPSTREAM_PORT]


### PR DESCRIPTION
The initial setup wizard (`RbacConfigFlow.async_step_user`) already
refuses a proxy port equal to the upstream port, since one process can't
bind both. The options flow used for later reconfiguration
(`RbacOptionsFlow.async_step_init`) had no such check, so reopening the
integration's options and setting both ports to the same value was
accepted silently — producing a config the proxy can't actually start
with.

This mirrors the existing check and its `port_conflict` error string
(added to `options.error` in `strings.json`/`translations/en.json`, since
options-flow errors are looked up separately from config-flow errors),
and re-shows the submitted values on error instead of resetting the form
back to the previously saved ones.