### PR TITLE
Remove unused CONF_FAIL_OPEN constant

### DIFF
--- a/custom_components/ha_rbac/const.py
+++ b/custom_components/ha_rbac/const.py
@@ -16,7 +16,6 @@ CONF_PROXY_PORT: Final = "proxy_port"
 CONF_BIND_ADDRESS: Final = "bind_address"
 CONF_UPSTREAM_HOST: Final = "upstream_host"
 CONF_UPSTREAM_PORT: Final = "upstream_port"
-CONF_FAIL_OPEN: Final = "fail_open"
 # Whether this integration moves Home Assistant's own listener for you.
 CONF_MANAGE_HTTP: Final = "manage_http"
 # Put Home Assistant back where it was if this integration is removed or


### PR DESCRIPTION
`CONF_FAIL_OPEN` is defined in `const.py` but never referenced anywhere
else in the codebase — not in `config_flow.py`, not in `__init__.py`, not
in the request path, not in the test suite. Confirmed with a repo-wide
grep before opening this.

A "fail open" constant that isn't wired into anything is worse than no
constant at all: it invites a future contributor (or reviewer) to assume
there's a fail-open/fail-closed toggle governing behavior somewhere, when
there isn't one. Removing it rather than wiring it up, since nothing in
the current design calls for such a toggle.

No behavior change.