### PR TITLE
Refuse to install in front of an instance that terminates TLS itself

### DIFF
--- a/README.md
+++ b/README.md
@@ -330,6 +330,26 @@ hop, because it appends to the `X-Forwarded-For` chain rather than replacing it.
 
 </details>
 
+<details>
+<summary><strong>What if Home Assistant holds the HTTPS certificate itself?</strong></summary>
+
+<br>
+
+Then this can't be installed, and it says so rather than trying. If you've set
+**SSL certificate** and **SSL key** under Settings > System > Network, Home
+Assistant is the thing terminating TLS. This proxy speaks plain HTTP on both
+sides, so taking over that port would mean answering plaintext on it.
+
+To use this, move the certificate to a reverse proxy in front of Home
+Assistant — NGINX, Traefik and Caddy all do it in a few lines — and clear those
+two fields. That's the arrangement in the question above, and it needs nothing
+else.
+
+This only applies when Home Assistant itself holds the certificate. If TLS is
+already terminated somewhere else, there's nothing to change.
+
+</details>
+
 ## Contributing
 
 Bug reports from real houses are the most useful thing right now, especially

--- a/custom_components/ha_rbac/__init__.py
+++ b/custom_components/ha_rbac/__init__.py
@@ -86,6 +86,24 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     # port was accepted, redisplayed, and silently ignored.
     config = {**entry.data, **entry.options}
 
+    # Before anything is built, and long before anything is staged. The config
+    # flow refuses this too, but a certificate can be added to an instance that
+    # was set up without one, and the move is what turns that into an outage:
+    # it would take the port Home Assistant answers HTTPS on and start
+    # answering plaintext there. Refusing setup is the fail-closed direction --
+    # a proxy that came up here would forward plaintext to a TLS listener and
+    # serve nothing but errors, while looking installed.
+    if http_config.terminates_tls(hass):
+        raise ConfigEntryNotReady(
+            "Home Assistant is serving HTTPS itself, and this proxy speaks "
+            "plain HTTP on both sides, so it cannot sit in front of it. Either "
+            "move the certificate to a reverse proxy in front of Home "
+            "Assistant and clear SSL certificate under Settings > System > "
+            "Network, or remove this integration. This is not the same as "
+            "NGINX, Traefik or Cloudflare terminating TLS for you, which needs "
+            "no change and keeps working"
+        )
+
     store = RbacStore(hass)
     await store.async_load()
 

--- a/custom_components/ha_rbac/config_flow.py
+++ b/custom_components/ha_rbac/config_flow.py
@@ -104,6 +104,14 @@ class RbacConfigFlow(ConfigFlow, domain=DOMAIN):
         """Configure the proxy."""
         self._async_abort_entries_match()
 
+        # Refused here rather than warned about, because there is no
+        # configuration of this form that works against an instance holding its
+        # own certificate -- the proxy is plaintext on both sides. Letting the
+        # flow finish would offer the move on the next step, and accepting that
+        # takes the HTTPS port to answer plaintext on it.
+        if http_config.terminates_tls(self.hass):
+            return self.async_abort(reason="tls_terminated")
+
         errors: dict[str, str] = {}
         if user_input is not None:
             data = {

--- a/custom_components/ha_rbac/http_config.py
+++ b/custom_components/ha_rbac/http_config.py
@@ -22,7 +22,7 @@ import logging
 from ipaddress import ip_address, ip_network
 from typing import Any
 
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.exceptions import HomeAssistantError
 
 _LOGGER = logging.getLogger(__name__)
@@ -185,6 +185,33 @@ def is_aligned(hass: HomeAssistant, upstream_port: int) -> bool:
         and all(_is_loopback_host(host) for host in hosts)
         and getattr(http, "server_port", None) == upstream_port
     )
+
+
+@callback
+def terminates_tls(hass: HomeAssistant) -> bool:
+    """Return True if Home Assistant is serving HTTPS itself.
+
+    The proxy speaks plain HTTP on both sides: it listens without an SSL context
+    and builds its upstream URL with `scheme="http"`. So an instance holding its
+    own certificate cannot be sat in front of. Moving it would take the port it
+    answers HTTPS on and start answering plaintext there, while forwarding
+    plaintext to a listener that expects TLS -- a mismatch at both ends, and an
+    outage until Home Assistant's own five-minute revert undoes it.
+
+    Read from the running server rather than from the store, for the same reason
+    `is_aligned` is: the store holds what was set under Settings > System >
+    Network, and `ssl_certificate` is just as often set in `configuration.yaml`,
+    where the store never sees it. What the server is actually doing is the
+    question.
+
+    This is not the reverse-proxy case. NGINX, Traefik or Cloudflare terminating
+    TLS and forwarding to Home Assistant over HTTP leaves `ssl_certificate`
+    unset here, which is why that setup keeps working unchanged.
+    """
+    http = getattr(hass, "http", None)
+    if http is None:
+        return False
+    return bool(getattr(http, "ssl_certificate", None))
 
 
 async def async_can_manage(hass: HomeAssistant) -> bool:

--- a/custom_components/ha_rbac/strings.json
+++ b/custom_components/ha_rbac/strings.json
@@ -32,7 +32,8 @@
       "port_conflict": "The proxy cannot listen on the same port as Home Assistant."
     },
     "abort": {
-      "already_configured": "Access control is already set up."
+      "already_configured": "Access control is already set up.",
+      "tls_terminated": "Home Assistant is serving HTTPS itself, with its own certificate under Settings > System > Network. This proxy speaks plain HTTP on both sides, so it cannot sit in front of it: taking the HTTPS port would mean answering plaintext on it.\n\nTo use this, put a reverse proxy such as NGINX, Traefik or Caddy in front of Home Assistant to hold the certificate, then clear SSL certificate and SSL key here. That arrangement is supported and needs no other change.\n\nIf TLS is already terminated somewhere else, nothing needs doing: this message only appears when Home Assistant holds the certificate itself."
     }
   },
   "options": {

--- a/custom_components/ha_rbac/translations/en.json
+++ b/custom_components/ha_rbac/translations/en.json
@@ -32,7 +32,8 @@
       "port_conflict": "The proxy cannot listen on the same port as Home Assistant."
     },
     "abort": {
-      "already_configured": "Access control is already set up."
+      "already_configured": "Access control is already set up.",
+      "tls_terminated": "Home Assistant is serving HTTPS itself, with its own certificate under Settings > System > Network. This proxy speaks plain HTTP on both sides, so it cannot sit in front of it: taking the HTTPS port would mean answering plaintext on it.\n\nTo use this, put a reverse proxy such as NGINX, Traefik or Caddy in front of Home Assistant to hold the certificate, then clear SSL certificate and SSL key here. That arrangement is supported and needs no other change.\n\nIf TLS is already terminated somewhere else, nothing needs doing: this message only appears when Home Assistant holds the certificate itself."
     }
   },
   "options": {

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -248,3 +248,39 @@ async def test_a_valid_reconfigure_is_saved(options: RbacOptionsFlow) -> None:
     assert step["type"] is FlowResultType.CREATE_ENTRY
     assert step["data"][CONF_PROXY_PORT] == 9000
     assert step["data"][CONF_UPSTREAM_PORT] == PORTS[CONF_UPSTREAM_PORT]
+
+
+async def test_the_wizard_refuses_an_instance_holding_its_own_certificate(
+    flow: RbacConfigFlow,
+) -> None:
+    """Reported as an outage waiting to happen (#29).
+
+    The wizard offers the port Home Assistant answers on, which on an instance
+    terminating TLS is the HTTPS one. Accepting the move would take 443 and
+    start answering plaintext on it, while forwarding plaintext to a listener
+    still expecting TLS -- broken at both ends until Home Assistant's own
+    five-minute revert undoes it. There is no answer to the form that works, so
+    the form is not shown.
+    """
+    with patch(
+        "custom_components.ha_rbac.http_config.terminates_tls", return_value=True
+    ):
+        step = await flow.async_step_user()
+
+    assert step["type"] is FlowResultType.ABORT
+    assert step["reason"] == "tls_terminated"
+
+
+async def test_a_reverse_proxy_terminating_tls_is_still_offered_the_move(
+    flow: RbacConfigFlow,
+) -> None:
+    """The documented setup, and the one the refusal above must not catch.
+
+    NGINX, Traefik or Cloudflare holding the certificate and forwarding over
+    HTTP leaves Home Assistant's own `ssl_certificate` unset, so nothing about
+    that arrangement changes.
+    """
+    step = await flow.async_step_user(PORTS)
+
+    assert step["type"] is FlowResultType.FORM
+    assert step["step_id"] == "move"

--- a/tests/test_http_config.py
+++ b/tests/test_http_config.py
@@ -186,3 +186,35 @@ async def test_an_unrecognisable_home_assistant_is_reported_not_guessed(
         side_effect=AttributeError("moved in a later release"),
     ):
         assert await http_config.async_can_manage(hass) is False
+
+
+@pytest.mark.parametrize(
+    ("certificate", "expected"),
+    [
+        (None, False),
+        ("", False),
+        ("/ssl/fullchain.pem", True),
+    ],
+    ids=["no-certificate", "empty-certificate", "home-assistant-holds-it"],
+)
+async def test_home_assistant_terminating_tls_is_recognised(
+    hass: HomeAssistant, certificate: Any, expected: bool
+) -> None:
+    """The proxy is plaintext on both sides, so this decides whether it can run.
+
+    Read from the running server, not the store: `ssl_certificate` is as often
+    set in `configuration.yaml` as under Settings > System > Network, and the
+    store never sees the former. A reverse proxy holding the certificate
+    instead leaves this unset, which is why that arrangement keeps working.
+    """
+    server = SimpleNamespace(ssl_certificate=certificate)
+    with patch.object(hass, "http", server, create=True):
+        assert http_config.terminates_tls(hass) is expected
+
+
+async def test_tls_is_not_assumed_before_the_http_server_exists(
+    hass: HomeAssistant,
+) -> None:
+    """Answering yes with nothing to read would refuse setup on every install."""
+    with patch.object(hass, "http", None, create=True):
+        assert http_config.terminates_tls(hass) is False

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -100,6 +100,50 @@ async def test_unload_releases_everything(
     assert DATA_RBAC not in hass.data
 
 
+async def test_setup_refuses_an_instance_that_terminates_tls(
+    hass: HomeAssistant, socket_enabled: None
+) -> None:
+    """Refused before anything is staged, and above all before any restart.
+
+    Reported as #29. The proxy is plaintext on both sides, so an instance
+    holding its own certificate cannot be sat in front of. Coming up anyway
+    would forward plaintext to a listener expecting TLS and serve nothing but
+    errors, while reading as installed and enforcing -- and if the move ran, it
+    would take the HTTPS port to answer plaintext on it, which is an outage
+    until Home Assistant's own revert undoes it.
+
+    The config flow refuses this too. This is the second half: a certificate
+    can be added to an instance that was set up without one.
+    """
+    for domain in ("http", "websocket_api"):
+        await async_setup_component(hass, domain, {"http": {}})
+    await hass.async_block_till_done()
+
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            CONF_PROXY_PORT: _free_port(),
+            CONF_BIND_ADDRESS: "127.0.0.1",
+            CONF_UPSTREAM_HOST: "127.0.0.1",
+            CONF_UPSTREAM_PORT: 8124,
+            CONF_MANAGE_HTTP: True,
+        },
+    )
+    entry.add_to_hass(hass)
+
+    with (
+        patch.object(hass.http, "ssl_certificate", "/ssl/fullchain.pem", create=True),
+        patch(
+            "custom_components.ha_rbac.http_config.async_stage", new=AsyncMock()
+        ) as stage,
+        pytest.raises(ConfigEntryNotReady, match="serving HTTPS itself"),
+    ):
+        await async_setup_entry(hass, entry)
+
+    stage.assert_not_called()
+    assert DATA_RBAC not in hass.data
+
+
 async def test_a_reload_rebinds_the_port(
     hass: HomeAssistant, entry: MockConfigEntry
 ) -> None:


### PR DESCRIPTION
Fixes #29.

The wizard offers the port Home Assistant answers on today. On an instance holding its own certificate that is the HTTPS port, so accepting the move staged `443` for a plaintext listener while forwarding plaintext to a Home Assistant that still expects TLS — a mismatch at both ends, with a restart in the middle and no way back until Home Assistant's own five-minute revert undid it.

The proxy is plaintext on both sides by construction (`web.TCPSite` with no SSL context, upstream built with `scheme="http"`), so there is no answer to that form that works. Rather than warn, it refuses:

- **Config flow** aborts with `tls_terminated`, explaining the route out: put the certificate on a reverse proxy in front, then clear the two fields.
- **Setup** refuses too, before anything is staged, because a certificate can be added to an instance that was set up without one. Confirmed by removing the guard: setup runs straight on to stage the move and call `homeassistant.restart`.

Detection reads `hass.http.ssl_certificate` from the running server rather than the HTTP config store, for the same reason `is_aligned` does — `ssl_certificate` is as often set in `configuration.yaml`, which the store never sees.

The reverse-proxy case is the one this must not catch: NGINX, Traefik or Cloudflare holding the certificate leaves `ssl_certificate` unset here, so that arrangement is untouched. Pinned by its own test.

The issue notes the case was undocumented; added a README entry saying plainly that it can't be installed this way and what to do instead.

Not attempting the reporter's option 1 (moving the certificate onto the proxy listener and putting Home Assistant on plain HTTP over loopback). That is a real feature, it changes the documented recovery route in `DESIGN.md`, and getting TLS wrong in an access-control proxy is worse than declining it. This is their option 2, which they suggested as the useful minimum.

Full suite: 442 passing, ruff clean.