### PR TITLE
Say what a schedule does not bound

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,6 +230,23 @@ trim another. [The precise rule is in DESIGN.md](https://github.com/FezVrasta/ha
 </details>
 
 <details>
+<summary><strong>Does a schedule limit how far back someone can look?</strong></summary>
+
+<br>
+
+No. A schedule decides **when the role is in force**, not which slice of the
+past it can read. Give a cleaner weekday mornings and, during those mornings,
+they can pull the full history of every entity the role lets them see —
+including the evenings and weekends they were never here for.
+
+So a schedule is the right tool for "only while they're working" and the wrong
+one for "only what happened while they were working". If someone shouldn't see
+an entity's past, don't grant the entity: history is filtered by *what* the
+role can reach, and hidden entities are absent from it entirely.
+
+</details>
+
+<details>
 <summary><strong>Isn't this security by obscurity?</strong></summary>
 
 <br>

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -394,6 +394,16 @@ rather than ingress alone.
   for one does not match the other, and denying only the command left the
   service open until v0.15.1. [ASSIST.md](ASSIST.md) is what enforcing it rather
   than refusing it would take.
+- **A schedule bounds when, not when-from.** `active_at` asks whether a role is
+  in force *now*; nothing consults it about the period a request asks about. So
+  a role scheduled for Tuesday mornings is unrestricted in time while it is
+  active, and can read the whole recorded history of every entity it may see.
+  History is filtered by *what* the role reaches, through the same walk as any
+  other response, so a hidden entity is absent from it — but a visible one is
+  visible for all of its past. Scoping history to a role's windows would mean
+  filtering individual samples by timestamp on the largest responses Home
+  Assistant sends, and deciding what "its windows" means for a recurring
+  schedule; neither is settled. Raised as #37.
 - **Timing and existence oracles.** A denied entity is distinguishable from one
   that does not exist.
 - **Out-of-band capability URLs.** A signed path minted for the read-only


### PR DESCRIPTION
Refs #37.

#37 asks for history to respect a role's schedule. Checked, and the gap is real: `active_at(now)` only decides whether a role is in force *at this moment*. Nothing consults it about the period a request asks about, and there is no timestamp handling anywhere in `decide`, `extract` or `filters` — history is filtered by *entity*, through the same generic `prune` walk as any other response.

So a role scheduled for Tuesday mornings is unrestricted in time while it is active, and can read the whole recorded history of every entity it may see.

That is a reasonable thing to expect the other way round, and neither the README's "Days and hours" row nor DESIGN.md said otherwise. Both do now — README as a FAQ entry, DESIGN.md as a known limitation.

No behaviour change. Scoping history to a role's windows means filtering individual samples by timestamp on the largest responses Home Assistant sends, and settling what "its windows" means for a recurring schedule (only past Tuesday mornings? since the role was granted?). Neither is obvious, and a half-measure that clamps the requested range would read as a fix while still returning most of what was asked for. Left as a documented limit; #37 stays open.