### PR TITLE
Security: fix all six reported advisories, plus an SSRF the CodeQL alerts had found

### DIFF
--- a/custom_components/ha_rbac/catalog.py
+++ b/custom_components/ha_rbac/catalog.py
@@ -470,6 +470,26 @@ class Catalog:
         }
 
     @callback
+    def path_variables(self, method: str, path: str) -> dict[str, str]:
+        """Return every named segment of the matched route, resource key or not.
+
+        `path_resources` answers only for the names Home Assistant itself uses.
+        An integration registering its own route names its own things, and
+        Frigate's `/api/frigate/{instance}/recording/{camera}/...` names a
+        camera in a segment called `camera` -- a real entity, spelled the way
+        that integration spells it. Handing the raw segments to the same
+        registry-confirmed resolution the body gets is what binds the request
+        to `camera.bedroom`, so a role denying that camera is consulted.
+        """
+        if (route := self.route_for(method, path)) is None:
+            return {}
+        if (match := route.pattern.match(path)) is None:
+            return {}
+        return {
+            name: value for name, value in (match.groupdict() or {}).items() if value
+        }
+
+    @callback
     def path_service(self, method: str, path: str) -> tuple[str, str] | None:
         """Return the service a path calls, if it is the REST spelling of a call.
 

--- a/custom_components/ha_rbac/catalog.py
+++ b/custom_components/ha_rbac/catalog.py
@@ -8,9 +8,11 @@ across releases instead of rotting.
 
 import logging
 import re
+from collections.abc import Iterator
 from dataclasses import dataclass
 from fnmatch import fnmatch
 from functools import partial
+from types import CodeType
 from typing import Any
 
 from homeassistant.components.websocket_api import const as ws_const
@@ -47,14 +49,31 @@ def introspection_works() -> bool:
     silently classifying everything as open.
     """
     from homeassistant.components.websocket_api import decorators  # noqa: PLC0415
+    from homeassistant.exceptions import Unauthorized  # noqa: PLC0415
 
     def probe(hass: Any, connection: Any, msg: Any) -> None:
         """Do nothing; only its wrapper is inspected."""
+
+    def gated(request: Any) -> None:
+        """Refuse a non-administrator the way core's inline views do."""
+        if not request["hass_user"].is_admin:
+            raise Unauthorized
+
+    def branched(request: Any) -> Any:
+        """Read the same flag to choose an answer, and answer either way."""
+        return "all" if request["hass_user"].is_admin else "some"
 
     return (
         derive_tier(decorators.require_admin(probe)) == TIER_ADMIN
         and derive_tier(decorators.ws_require_user()(probe)) == TIER_USER
         and derive_tier(probe) == TIER_OPEN
+        # The second mechanism, for the views core gates without a decorator.
+        # Both halves: recognising the gate, and *not* mistaking a branch for
+        # one -- a detector that answered True to everything would read as
+        # working while making the whole REST surface administrator-only.
+        and gates_on_admin(gated)
+        and not gates_on_admin(branched)
+        and not gates_on_admin(probe)
     )
 
 
@@ -94,6 +113,73 @@ def derive_tier(handler: Any) -> str:
     if USER_WRAPPER_NAME in names:
         return TIER_USER
     return TIER_OPEN
+
+
+# How a view refuses a caller who is not an administrator. `Unauthorized` is
+# Home Assistant's own exception; the status names and their numbers cover the
+# views that answer with a bare response instead of raising.
+REFUSAL_NAMES = frozenset({"Unauthorized", "UNAUTHORIZED", "FORBIDDEN"})
+REFUSAL_CODES = frozenset({401, 403})
+ADMIN_ATTRIBUTE = "is_admin"
+
+
+def _code_objects(handler: Any) -> "Iterator[CodeType]":
+    """Yield the handler's own code and everything nested or wrapped inside it.
+
+    Comprehensions, closures and inner functions are separate code objects, and
+    a decorator puts the real body behind `__wrapped__`, so a check written in
+    any of those is only visible by walking the lot.
+    """
+    seen: set[int] = set()
+    stack: list[Any] = [handler]
+    while stack and len(seen) < 200:
+        current = stack.pop()
+        if isinstance(current, CodeType):
+            code = current
+        else:
+            if (wrapped := getattr(current, "__wrapped__", None)) is not None:
+                stack.append(wrapped)
+            code = getattr(current, "__code__", None)
+            if code is None:
+                continue
+        if id(code) in seen:
+            continue
+        seen.add(id(code))
+        yield code
+        stack.extend(c for c in code.co_consts if isinstance(c, CodeType))
+
+
+def gates_on_admin(handler: Any) -> bool:
+    """Return True if a handler refuses non-administrators in its own body.
+
+    Home Assistant marks most of its administrative surface with a decorator,
+    which `derive_tier` reads. Several core views do not: they check
+    `request["hass_user"].is_admin` inline and raise `Unauthorized` (or answer
+    401) themselves. `derive_tier` finds no decorator on those and reports the
+    handler as open, so the tier gate imposed nothing at all -- on, among
+    others, the whole Supervisor REST surface and `POST /api/states/{id}`,
+    which overwrites an entity's reported state without touching the device.
+
+    Testing for `is_admin` alone is too broad. `APIStatesView.get` reads it to
+    decide whether to filter the list it returns, and both branches answer:
+    that is a branch, not a gate, and treating it as one would make the single
+    most-used endpoint in Home Assistant administrator-only. So a refusal has
+    to appear beside it -- the shape of "not an admin, so you get nothing".
+    """
+    for code in _code_objects(handler):
+        # Globals and attributes land in `co_names`, but a name closed over
+        # from an enclosing scope -- an exception imported inside the function
+        # that defines the handler, say -- is a free variable and appears in
+        # neither. Both are the same thing to this question: a name the code
+        # refers to.
+        names = frozenset(code.co_names) | frozenset(code.co_freevars)
+        if ADMIN_ATTRIBUTE not in names:
+            continue
+        if names & REFUSAL_NAMES or REFUSAL_CODES.intersection(
+            const for const in code.co_consts if isinstance(const, int)
+        ):
+            return True
+    return False
 
 
 HTTP_METHODS = ("get", "post", "put", "patch", "delete", "head", "options")
@@ -255,7 +341,12 @@ def build_routes() -> list[RouteInfo]:
         for method in HTTP_METHODS:
             if (handler := getattr(cls, method, None)) is None:
                 continue
-            tiers[method] = derive_tier(handler)
+            tier = derive_tier(handler)
+            # A view that gates on `is_admin` in its own body carries no
+            # decorator for `derive_tier` to find, so it derives as open.
+            if tier == TIER_OPEN and gates_on_admin(handler):
+                tier = TIER_ADMIN
+            tiers[method] = tier
 
         urls = [url, *(getattr(cls, "extra_urls", None) or [])]
         for candidate in urls:

--- a/custom_components/ha_rbac/decide.py
+++ b/custom_components/ha_rbac/decide.py
@@ -394,6 +394,14 @@ class Decider:
         # check without counting as a bound, so a payload that names nothing a
         # schema recognises stays unbounded.
         entities |= entity_ids_in(payload, self._entity_exists)
+        if kind == KIND_HTTP:
+            # And an integration's own route names its own things: Frigate asks
+            # for `/recording/{camera}/...`, which is `camera.bedroom` spelled
+            # the way that integration spells it. Same resolution, same registry
+            # confirmation, so a segment naming nothing costs a failed lookup.
+            entities |= entity_ids_in(
+                self._catalog.path_variables(method, path), self._entity_exists
+            )
         key = POLICY_CONTROL if self._is_mutation(kind, name, payload) else POLICY_READ
 
         # 3. Resource gate. Every entity the request names must be permitted.

--- a/custom_components/ha_rbac/extract.py
+++ b/custom_components/ha_rbac/extract.py
@@ -102,6 +102,23 @@ def _add(target: Extracted, kind: str, value: Any) -> None:
 
     bucket = target.buckets[kind]
     for raw in values:
+        # A resource key is the one place a string reached the buckets without
+        # ever passing the template check the generic walk runs on every other
+        # string. Home Assistant renders `target.entity_id` server-side, so
+        # `{"entity_id": "{{ 'lock.gun_safe' }}"}` was recorded as an entity
+        # literally called `{{ 'lock.gun_safe' }}` -- a name no deny rule is
+        # written against, and one that a blanket `all` allow matched happily.
+        # The request then looked bounded, was allowed, and Home Assistant
+        # resolved the template to the entity the role denies.
+        #
+        # So it is treated as what it is: a template, whose reach has nothing
+        # to do with what it appears to name. That makes the command unbounded
+        # by the rule already in `is_bounded`, and the fake id is not recorded
+        # at all -- nothing downstream should be checking a policy against it,
+        # and it would only reappear as a resource in the deny log.
+        if _is_template(raw):
+            target.templated = True
+            continue
         # Home Assistant lowercases these on the way in (`cv.entity_id`), and
         # its policy lookup is an exact dict match -- so comparing the raw string
         # would let `LOCK.Front` miss a deny rule written for `lock.front`, and

--- a/custom_components/ha_rbac/extract.py
+++ b/custom_components/ha_rbac/extract.py
@@ -155,6 +155,47 @@ def extract(payload: Any) -> Extracted:
     return found
 
 
+def _qualified_by_key(
+    key: Any, value: Any, exists: "Callable[[str], bool]"
+) -> set[str]:
+    """Return entities a key names by domain, with the value as the object id.
+
+    An integration is free to invent its own vocabulary for something Home
+    Assistant already has an entity for. Frigate asks for a recording with
+    `{"camera": "bedroom"}`, and over its own REST route with `bedroom` as a
+    path segment -- naming `camera.bedroom` without ever writing an entity id,
+    so the resource gate saw a request that named nothing and the role's deny
+    rule for that camera was never consulted. The response is video, which
+    carries no entity data of its own and is therefore streamed rather than
+    filtered, so nothing downstream caught it either.
+
+    The rule is the same one the rest of this walk runs on: guess, then let the
+    registry decide. A key that is a domain qualifies its value, and
+    `camera.bedroom` counts only because it turns out to be a real entity. A
+    key named `camera` whose value names nothing costs one failed lookup.
+
+    Plural keys are tried singular, because a list of them is spelled
+    `cameras`. Values are lowercased for the same reason ids are everywhere
+    else here: the policy lookup is an exact match.
+    """
+    if not isinstance(key, str) or not key:
+        return set()
+    domains = [key.lower()]
+    if key.lower().endswith("s"):
+        domains.append(key.lower()[:-1])
+
+    values = value if isinstance(value, list) else [value]
+    found: set[str] = set()
+    for item in values:
+        if not isinstance(item, str) or not item or "." in item:
+            continue
+        for domain in domains:
+            candidate = f"{domain}.{item}".lower()
+            if exists(candidate):
+                found.add(candidate)
+    return found
+
+
 def entity_ids_in(payload: Any, exists: "Callable[[str], bool]") -> set[str]:
     """Return every entity a structure mentions, wherever it mentions it.
 
@@ -187,6 +228,7 @@ def entity_ids_in(payload: Any, exists: "Callable[[str], bool]") -> set[str]:
             for key, value in node.items():
                 if (candidate := entity_candidate(key)) and exists(candidate):
                     found.add(candidate)
+                found |= _qualified_by_key(key, value, exists)
                 stack.append((value, depth + 1))
         elif isinstance(node, list):
             stack.extend((item, depth + 1) for item in node)

--- a/custom_components/ha_rbac/filters.py
+++ b/custom_components/ha_rbac/filters.py
@@ -13,6 +13,7 @@ from typing import Any
 from homeassistant.auth.permissions.const import POLICY_READ
 from homeassistant.core import HomeAssistant
 
+from .const import EVENT_RBAC_DENIED
 from .extract import entity_candidate
 
 # Keys of the compressed state-diff protocol used by subscribe_entities.
@@ -166,7 +167,33 @@ class FilterRegistry:
         return prune(ctx, payload)
 
     def filter_event(self, command: str, ctx: FilterContext, payload: Any) -> Any:
-        """Filter one streamed event, falling back to the generic walk."""
+        """Filter one streamed event, falling back to the generic walk.
+
+        Every event frame the proxy relays passes through here, whatever the
+        subscription was called, so this is where an event that must not reach
+        a filtered connection at all is dropped -- ahead of any per-command
+        filter and of the generic walk.
+
+        There is exactly one: this integration's own denial event. It carries
+        `detail`, which names commands, tiers and entity ids and is documented
+        in `decide.py` as a diagnostic that must not reach an end user, plus
+        the id and name of whoever was refused. It was reaching every
+        restricted user on the instance -- `subscribe_events` with no filter is
+        an ordinary command that every frontend session issues on load -- and
+        neither the state-changed filter nor `prune` touched it, because
+        `resources` is not a key either of them recognises and `detail` is free
+        text. So a guest could watch every refusal in the house, learn the
+        entity ids of things their own role hides entirely, and see which
+        household member attempted what.
+
+        Dropped rather than redacted: nothing a filtered connection does needs
+        it. A refused request already carries its own `message` in the reply,
+        and the deny log itself is behind an admin-only websocket command. A
+        connection that is not being filtered never reaches this code, so
+        automations and the panel are unaffected.
+        """
+        if isinstance(payload, dict) and payload.get("event_type") == EVENT_RBAC_DENIED:
+            return None
         if (func := self._event.get(command)) is not None:
             return func(ctx, payload)
         return prune(ctx, payload)

--- a/custom_components/ha_rbac/filters.py
+++ b/custom_components/ha_rbac/filters.py
@@ -13,7 +13,8 @@ from typing import Any
 from homeassistant.auth.permissions.const import POLICY_READ
 from homeassistant.core import HomeAssistant
 
-from .extract import entity_candidate
+from .const import KEY_ENTITY, RESOURCE_KEYS
+from .extract import Extracted, entity_candidate
 
 # Keys of the compressed state-diff protocol used by subscribe_entities.
 # Within one entity's compressed state, "a" holds its attributes; at the event
@@ -200,6 +201,45 @@ def _looks_like_entity_id(value: Any) -> bool:
     return isinstance(value, str) and value.count(".") == 1 and " " not in value
 
 
+def _container_visible(ctx: FilterContext, node: dict[str, Any]) -> bool:
+    """Return True unless this object names a container the role cannot see.
+
+    A device, area, label or floor stands for the entities inside it, so the
+    question is whether the role can read any of them. If it can read none, the
+    container is one it is not supposed to know exists, and the object naming it
+    goes. If it can read some, the object stays and the walk keeps pruning what
+    is inside it -- the same treatment an area gets everywhere else.
+
+    A reference that resolves to nothing is left alone rather than treated as
+    denied. `expand_to_entities` drops ids that are not in the registries, and a
+    `device_id` in a Z-Wave payload is a Z-Wave node id, not a Home Assistant
+    device; refusing on that basis would empty responses that name no Home
+    Assistant resource at all.
+    """
+    # Imported here because `decide` imports this module: the expansion is one
+    # already-tested implementation of "what entities does this stand for", and
+    # a second one in a security path is a second one to get wrong.
+    from .decide import expand_to_entities  # noqa: PLC0415
+
+    found = Extracted()
+    buckets = found.buckets
+    named = False
+    for key, kind in RESOURCE_KEYS.items():
+        if kind == KEY_ENTITY or (value := node.get(key)) is None:
+            continue
+        for item in value if isinstance(value, list) else [value]:
+            if isinstance(item, str):
+                buckets[kind].add(item)
+                named = True
+    if not named:
+        return True
+
+    entities = expand_to_entities(ctx.hass, found)
+    if not entities:
+        return True
+    return any(ctx.readable(entity_id) for entity_id in entities)
+
+
 def prune(ctx: FilterContext, node: Any) -> Any:
     """Drop anything carrying a denied entity id.
 
@@ -211,6 +251,16 @@ def prune(ctx: FilterContext, node: Any) -> Any:
     if isinstance(node, dict):
         entity_id = node.get("entity_id") or node.get(DISPLAY_ENTITY_ID)
         if _looks_like_entity_id(entity_id) and not ctx.readable(entity_id):
+            return None
+
+        # An entity id is not the only way an object names something. The
+        # request side treats `device_id`, `area_id`, `label_id` and `floor_id`
+        # as first-class, and this walk did not: an event echoing one of those
+        # rather than a resolved entity went through untouched. Home Assistant
+        # fires `call_service` with the call's *original* target, before it is
+        # resolved, so a role subscribed to events could watch a service being
+        # invoked against an area or device it has no access to at all.
+        if not _container_visible(ctx, node):
             return None
 
         # History and statistics return states in the compressed form, where
@@ -674,3 +724,57 @@ def strip_denied_addons(ctx: FilterContext, endpoint: str, result: Any) -> Any:
         }
 
     return {**result, "data": cleaned} if wrapped else cleaned
+
+
+def _filter_history_states(ctx: FilterContext, states: Any) -> Any:
+    """Filter a mapping of entity id -> that entity's compressed states.
+
+    History is the one response shape where the entity a sample belongs to is
+    not in the sample. Each one carries only `s`, `a`, `lu`, `lc`, keyed by
+    entity id one level up, so the generic walk recovered no entity id and
+    stripped attributes with `None` -- which matches only the rules written
+    against no entity or domain in particular. A rule scoped to an entity or a
+    domain, "hide latitude and longitude on person.*", was silently skipped for
+    history while working correctly for `get_states` and `subscribe_entities`.
+
+    Here the key is the entity id, so it is threaded down into the strip and the
+    rule matches. Unreadable entities go entirely rather than being emptied: an
+    entity id with a zero-length history still says the entity exists.
+    """
+    if not isinstance(states, dict):
+        return prune(ctx, states)
+    out: dict[str, Any] = {}
+    for entity_id, samples in states.items():
+        if _looks_like_entity_id(entity_id) and not ctx.readable(entity_id):
+            continue
+        named = entity_id if _looks_like_entity_id(entity_id) else None
+        if not ctx.hides_attributes or not isinstance(samples, list):
+            out[entity_id] = samples
+            continue
+        out[entity_id] = [
+            {
+                **sample,
+                COMPRESSED_ATTRIBUTES: ctx.strip_attributes(
+                    named, sample[COMPRESSED_ATTRIBUTES]
+                ),
+            }
+            if isinstance(sample, dict)
+            and isinstance(sample.get(COMPRESSED_ATTRIBUTES), dict)
+            else sample
+            for sample in samples
+        ]
+    return out
+
+
+@REGISTRY.result("history/history_during_period")
+def _filter_history_result(ctx: FilterContext, result: Any) -> Any:
+    """Filter the entity-keyed mapping the result is."""
+    return _filter_history_states(ctx, result)
+
+
+@REGISTRY.event("history/stream", "history/history_during_period")
+def _filter_history_event(ctx: FilterContext, event: Any) -> Any:
+    """Filter the same mapping, which a stream frame wraps under `states`."""
+    if not isinstance(event, dict) or not isinstance(event.get("states"), dict):
+        return prune(ctx, event)
+    return {**event, "states": _filter_history_states(ctx, event["states"])}

--- a/custom_components/ha_rbac/filters.py
+++ b/custom_components/ha_rbac/filters.py
@@ -564,6 +564,28 @@ def _filter_get_services(ctx: FilterContext, result: Any) -> Any:
     }
 
 
+def _lovelace_entity_keys(node: dict[str, Any]) -> list[str]:
+    """Return the keys of one card that name entities.
+
+    The three Lovelace itself uses, plus the convention custom cards follow
+    when they add their own: a suffix of `_entity` or `_entities`. Advanced
+    Camera Card asks for `camera_entity`, and a denied camera stayed in the
+    dashboard configuration under it -- which hands over the entity id of
+    something the role hides entirely, and with it the name to go looking for
+    on that integration's own routes.
+
+    A suffix rather than a longer list, because the list is the thing this
+    project exists to avoid: a card key nobody has heard of is covered the day
+    somebody writes it, as long as it is spelled the way the others are.
+    """
+    return [
+        key
+        for key in node
+        if isinstance(key, str)
+        and (key in LOVELACE_ENTITY_KEYS or key.endswith(("_entity", "_entities")))
+    ]
+
+
 @REGISTRY.result("lovelace/config")
 def _filter_lovelace(ctx: FilterContext, result: Any) -> Any:
     """Drop cards referring to entities the role cannot read.
@@ -576,7 +598,7 @@ def _filter_lovelace(ctx: FilterContext, result: Any) -> Any:
 
     def scrub(node: Any) -> Any:
         if isinstance(node, dict):
-            for key in LOVELACE_ENTITY_KEYS:
+            for key in _lovelace_entity_keys(node):
                 value = node.get(key)
                 if _looks_like_entity_id(value) and not ctx.readable(value):
                     return None

--- a/custom_components/ha_rbac/ingress.py
+++ b/custom_components/ha_rbac/ingress.py
@@ -12,6 +12,7 @@ endpoints while leaving the add-on's own web UI reachable by anyone who knows
 its ingress path -- a value that is stable for the life of the installation.
 """
 
+import asyncio
 import logging
 import time
 from typing import Any
@@ -75,6 +76,9 @@ class IngressGuard:
         self._sessions: dict[str, tuple[str, float]] = {}
         self._slugs: dict[str, str] = {}
         self._loaded_at: float | None = None
+        # Serialises the rebuild, so a miss during one waits for it rather than
+        # being answered from the map it is replacing.
+        self._reload_lock = asyncio.Lock()
 
     @callback
     def remember_session(self, session: str, user_id: str) -> None:
@@ -120,17 +124,40 @@ class IngressGuard:
         self._loaded_at = None
 
     async def async_slug_for(self, token: str) -> str | None:
-        """Return the add-on an ingress token belongs to, or None if it is none."""
-        if token in self._slugs:
-            return self._slugs[token]
-        # A miss is either a token that belongs to nothing or an add-on
-        # installed since the map was built, and only a rebuild tells them
-        # apart. Guessing "not an add-on" would forward it unguarded.
-        now = time.monotonic()
-        if self._loaded_at is None or now - self._loaded_at > MISS_RELOAD_INTERVAL:
-            self._loaded_at = now
-            await self._async_load()
-        return self._slugs.get(token)
+        """Return the add-on an ingress token belongs to, or None if it is none.
+
+        A miss is either a token that belongs to nothing or an add-on installed
+        since the map was built, and only a rebuild tells them apart. Guessing
+        "not an add-on" would forward it unguarded, which is the whole thing
+        this exists to prevent.
+
+        The rebuild is serialised. The freshness stamp used to be written
+        *before* the reload it stands for, and the reload is real Supervisor
+        I/O -- a list call plus one info call per add-on. So a second request
+        for the same unknown token arriving during that window read the stamp
+        as fresh, skipped the rebuild, and was answered from the map as it
+        stood before it: `None`, which the proxy reads as "not an add-on" and
+        forwards with no permission check at all. Two near-simultaneous
+        requests were enough, and a cold cache after a restart is exactly when
+        it happens.
+
+        So concurrent misses queue on the lock and the first one's rebuild
+        answers all of them, with the map re-read on the way in because it may
+        have been filled while they waited.
+        """
+        if (slug := self._slugs.get(token)) is not None:
+            return slug
+        async with self._reload_lock:
+            if (slug := self._slugs.get(token)) is not None:
+                return slug
+            now = time.monotonic()
+            if self._loaded_at is None or now - self._loaded_at > MISS_RELOAD_INTERVAL:
+                # `_async_load` stamps `_loaded_at` itself, once it has actually
+                # loaded something. A failure raises and leaves the stamp alone,
+                # so the next request tries again rather than being told the
+                # map is fresh.
+                await self._async_load()
+            return self._slugs.get(token)
 
     async def _async_load(self) -> None:
         """Build the token -> add-on map from Supervisor."""

--- a/custom_components/ha_rbac/proxy.py
+++ b/custom_components/ha_rbac/proxy.py
@@ -367,8 +367,26 @@ class RbacProxy:
 
     @callback
     def _upstream_url(self, request: web.Request) -> URL:
-        """Return the upstream URL, preserving path and query byte for byte."""
-        return self._base.join(URL(request.rel_url.raw_path_qs, encoded=True))
+        """Return the upstream URL, preserving path and query byte for byte.
+
+        The path is anchored to a single leading slash first. `join` resolves
+        its argument against the base the way a browser resolves a link, so a
+        request path beginning with two slashes is a *protocol-relative URL*:
+        `//example.com/x` names a host, and joining it replaced the upstream
+        entirely. The proxy would then fetch `http://example.com/x` from the
+        Home Assistant machine and relay the answer -- reaching anything that
+        host can reach, including the rest of the home network and a cloud
+        instance's metadata endpoint, and doing it before any user is resolved,
+        so no login was needed.
+
+        Collapsing the slashes is what `join` already does to three or more of
+        them (`///x` resolves to `/x`), so this only makes the two-slash case
+        agree with the rest rather than changing any path Home Assistant
+        serves. Everything after the first segment is left byte for byte, which
+        the signed-path HMAC depends on.
+        """
+        raw = request.rel_url.raw_path_qs
+        return self._base.join(URL("/" + raw.lstrip("/"), encoded=True))
 
     @callback
     def _request_headers(self, request: web.Request) -> CIMultiDict[str]:

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -309,3 +309,80 @@ async def test_the_admin_default_survives_the_static_exception(
     assert catalog.tier_for_request("GET", "/robots.txt/anything") == TIER_ADMIN
     assert catalog.tier_for_request("GET", "/nothing/registered") == TIER_ADMIN
     assert catalog.tier_for_request("GET", "/api/error_log") == TIER_ADMIN
+
+
+async def test_a_view_that_gates_on_admin_inline_is_not_read_as_open(
+    hass: HomeAssistant,
+) -> None:
+    """GHSA-rf3j-8w24-5pc8: the decorator is not the only way core gates admin.
+
+    `derive_tier` reads Home Assistant's `require_admin` decorator off the
+    handler. Several core views carry no decorator and check
+    `request["hass_user"].is_admin` in the body instead, raising `Unauthorized`
+    themselves. Those derived as *open* -- not as the fail-closed admin default
+    used for a route this build has never seen -- so the tier gate imposed
+    nothing on them for any role.
+
+    `POST /api/states/{entity_id}` is the one to hold onto: it overwrites what
+    Home Assistant reports for an entity without going near the device, which
+    is why core reserves it to administrators, and a role with ordinary control
+    of that entity satisfied the resource gate.
+    """
+    import homeassistant.components.api  # noqa: F401, PLC0415
+
+    await async_setup_component(hass, "http", {})
+    await async_setup_component(hass, "api", {})
+    await hass.async_block_till_done()
+    catalog = Catalog(hass)
+    catalog.rebuild()
+
+    assert catalog.tier_for_request("POST", "/api/states/light.kitchen") == TIER_ADMIN
+    assert catalog.tier_for_request("DELETE", "/api/states/light.kitchen") == TIER_ADMIN
+
+
+async def test_reading_the_state_list_stays_open(hass: HomeAssistant) -> None:
+    """The check that must not be mistaken for a gate.
+
+    `APIStatesView.get` reads `is_admin` too, but to choose whether to filter
+    the list rather than whether to answer at all -- both branches return
+    states. Treating that as a gate would make the single most-used endpoint in
+    Home Assistant administrator-only and empty every restricted dashboard,
+    which is why the detector wants a refusal beside the flag rather than the
+    flag alone.
+    """
+    import homeassistant.components.api  # noqa: F401, PLC0415
+
+    await async_setup_component(hass, "http", {})
+    await async_setup_component(hass, "api", {})
+    await hass.async_block_till_done()
+    catalog = Catalog(hass)
+    catalog.rebuild()
+
+    assert catalog.tier_for_request("GET", "/api/states") == TIER_OPEN
+
+
+def test_the_inline_gate_detector_reads_both_shapes() -> None:
+    """Raising and answering 401 are both refusals; branching is not."""
+    from homeassistant.exceptions import Unauthorized  # noqa: PLC0415
+
+    from custom_components.ha_rbac.catalog import gates_on_admin  # noqa: PLC0415
+
+    def raises(request):
+        if not request["hass_user"].is_admin:
+            raise Unauthorized
+
+    def answers_401(request):
+        if not request["hass_user"].is_admin:
+            return {"status": 401}
+        return {"status": 200}
+
+    def branches(request):
+        return "all" if request["hass_user"].is_admin else "mine"
+
+    def unrelated(request):
+        return request.query.get("q")
+
+    assert gates_on_admin(raises) is True
+    assert gates_on_admin(answers_401) is True
+    assert gates_on_admin(branches) is False
+    assert gates_on_admin(unrelated) is False

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -1,5 +1,7 @@
 """Tests for response filtering."""
 
+import json
+
 from homeassistant.auth.permissions.const import POLICY_READ
 from homeassistant.core import HomeAssistant
 
@@ -605,3 +607,112 @@ async def test_media_that_is_not_an_entity_is_left_alone(
         },
     )
     assert [child["title"] for child in result["children"]] == ["song.mp3"]
+
+
+def _hiding(hass: HomeAssistant, hidden: dict[str, set[str]]) -> FilterContext:
+    """Return a context hiding named attributes on specific entities.
+
+    Targeted the way a real rule is -- "hide latitude on person.jane" -- so a
+    filter that loses the entity id cannot match it, which is the bug.
+    """
+    return FilterContext(
+        hass,
+        lambda entity_id, key: True,
+        None,
+        lambda entity_id, name: name in hidden.get(entity_id, set()),
+    )
+
+
+async def test_history_hides_attributes_a_targeted_rule_names(
+    hass: HomeAssistant,
+) -> None:
+    """GHSA-px8f-g9qh-j6vc: history is where the entity is not in the sample.
+
+    A compressed history sample carries only `s`, `a`, `lu` and `lc`, keyed by
+    entity id one level up, so the generic walk recovered no entity id and
+    stripped attributes with `None`. Only a rule written against no entity or
+    domain in particular matches that, so "hide latitude and longitude on
+    person.jane" was silently skipped for history while working correctly for
+    `get_states` and `subscribe_entities` -- the location a role was written to
+    withhold came back in full through a different command.
+    """
+    ctx = _hiding(hass, {"person.jane": {"latitude", "longitude"}})
+    states = {
+        "person.jane": [
+            {
+                "s": "home",
+                "a": {"latitude": 51.5, "longitude": -0.1, "icon": "x"},
+                "lu": 1,
+            }
+        ],
+        "light.kitchen": [{"s": "on", "a": {"brightness": 5}, "lu": 2}],
+    }
+
+    result = REGISTRY.filter_result("history/history_during_period", ctx, states)
+    assert result["person.jane"][0]["a"] == {"icon": "x"}
+    assert result["light.kitchen"][0]["a"] == {"brightness": 5}, "untouched"
+
+    event = REGISTRY.filter_event(
+        "history/stream", ctx, {"states": states, "start_time": 1, "end_time": 2}
+    )
+    assert event["states"]["person.jane"][0]["a"] == {"icon": "x"}
+    assert event["start_time"] == 1, "the frame around it survives"
+
+
+async def test_history_drops_an_entity_the_role_cannot_read(
+    hass: HomeAssistant,
+) -> None:
+    """An entity id with an empty history still says the entity exists."""
+    result = REGISTRY.filter_result(
+        "history/history_during_period",
+        _ctx(hass, {"lock.front"}),
+        {
+            "lock.front": [{"s": "locked", "a": {}, "lu": 1}],
+            "light.kitchen": [{"s": "on", "a": {}, "lu": 1}],
+        },
+    )
+    assert set(result) == {"light.kitchen"}
+
+
+async def test_an_event_naming_only_an_area_is_judged_by_it(
+    hass: HomeAssistant,
+) -> None:
+    """GHSA-px8f-g9qh-j6vc: the walk knew entity ids and nothing else.
+
+    Home Assistant fires `call_service` with the call's *original* target,
+    before it is resolved, so the payload names an area rather than any entity.
+    `device_id`, `area_id`, `label_id` and `floor_id` are first-class on the
+    request side and were not recognised here at all, so a role subscribed to
+    events could watch a service being invoked against an area containing
+    nothing it may see.
+    """
+    from homeassistant.helpers import area_registry as ar  # noqa: PLC0415
+    from homeassistant.helpers import entity_registry as er  # noqa: PLC0415
+
+    areas = ar.async_get(hass)
+    bedroom = areas.async_get_or_create("Bedroom")
+    entities = er.async_get(hass)
+    entry = entities.async_get_or_create("lock", "demo", "bed1")
+    entities.async_update_entity(entry.entity_id, area_id=bedroom.id)
+
+    ctx = _ctx(hass, {entry.entity_id})
+    event = {
+        "event_type": "call_service",
+        "data": {"domain": "lock", "service": "unlock", "service_data": {}},
+        "target": {"area_id": bedroom.id},
+    }
+
+    # The object naming the area goes, the same way one naming a denied entity
+    # does: the walk drops the object that carries the reference, not the frame
+    # around it. What is left no longer says which area, or that it exists.
+    filtered = prune(ctx, event)
+    assert "target" not in filtered
+    assert bedroom.id not in json.dumps(filtered)
+
+    # An area holding something readable is not hidden, and neither is a
+    # reference that resolves to no Home Assistant resource at all -- a
+    # `device_id` in a Z-Wave payload is a Z-Wave node id, not an HA device.
+    assert "target" in prune(_ctx(hass, set()), event)
+    assert prune(ctx, {"device_id": "a-zwave-node-id"}) == {
+        "device_id": "a-zwave-node-id"
+    }

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -1,5 +1,7 @@
 """Tests for response filtering."""
 
+import json
+
 from homeassistant.auth.permissions.const import POLICY_READ
 from homeassistant.core import HomeAssistant
 
@@ -605,3 +607,39 @@ async def test_media_that_is_not_an_entity_is_left_alone(
         },
     )
     assert [child["title"] for child in result["children"]] == ["song.mp3"]
+
+
+async def test_a_custom_card_key_naming_an_entity_is_scrubbed(
+    hass: HomeAssistant,
+) -> None:
+    """GHSA-23ch-3r34-x2hq, second half: `camera_entity` was not on the list.
+
+    Lovelace's own keys were enumerated, so a custom card naming its entity any
+    other way kept it. Advanced Camera Card uses `camera_entity`, and a denied
+    camera stayed in the dashboard configuration under it -- handing over the
+    entity id of something the role hides entirely, and with it the name to go
+    looking for on that integration's own routes.
+
+    Matched by the suffix the convention uses rather than by a longer list, so
+    a card key nobody has heard of is covered the day somebody writes it.
+    """
+    result = REGISTRY.filter_result(
+        "lovelace/config",
+        _ctx(hass, {"camera.bedroom"}),
+        {
+            "views": [
+                {
+                    "cards": [
+                        {
+                            "type": "custom:advanced-camera-card",
+                            "cameras": [{"camera_entity": "camera.bedroom"}],
+                        },
+                        {"type": "picture", "camera_entity": "camera.hall"},
+                    ]
+                }
+            ]
+        },
+    )
+
+    assert "camera.bedroom" not in json.dumps(result)
+    assert "camera.hall" in json.dumps(result), "a camera they may see stays"

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -609,7 +609,6 @@ async def test_media_that_is_not_an_entity_is_left_alone(
     assert [child["title"] for child in result["children"]] == ["song.mp3"]
 
 
-<<<<<<< HEAD
 def _hiding(hass: HomeAssistant, hidden: dict[str, set[str]]) -> FilterContext:
     """Return a context hiding named attributes on specific entities.
 
@@ -717,7 +716,8 @@ async def test_an_event_naming_only_an_area_is_judged_by_it(
     assert prune(ctx, {"device_id": "a-zwave-node-id"}) == {
         "device_id": "a-zwave-node-id"
     }
-=======
+
+
 async def test_a_custom_card_key_naming_an_entity_is_scrubbed(
     hass: HomeAssistant,
 ) -> None:
@@ -752,4 +752,3 @@ async def test_a_custom_card_key_naming_an_entity_is_scrubbed(
 
     assert "camera.bedroom" not in json.dumps(result)
     assert "camera.hall" in json.dumps(result), "a camera they may see stays"
->>>>>>> origin/security/bind-camera-references

--- a/tests/test_ingress.py
+++ b/tests/test_ingress.py
@@ -8,6 +8,7 @@ own web UI reachable to anyone holding its ingress path, which is stable for
 the life of the installation.
 """
 
+import asyncio
 import time
 
 import pytest
@@ -202,3 +203,49 @@ async def test_the_first_lookup_always_builds_the_map(hass: HomeAssistant) -> No
     guard._async_load = _fake_load
     assert await guard.async_slug_for("anything") is None
     assert loads == 1
+
+
+async def test_a_miss_during_a_rebuild_waits_for_it(hass: HomeAssistant) -> None:
+    """GHSA-p5x6-gpc8-rqh6: a concurrent miss was answered from the stale map.
+
+    The freshness stamp was written before the reload it stands for, and the
+    reload is real Supervisor I/O -- a list call plus one info call per add-on.
+    So a second request for the same unknown token, arriving while the first
+    was still awaiting Supervisor, read the stamp as fresh, skipped the
+    rebuild, and got `None` from the map as it stood before it. The proxy
+    reads `None` as "not an add-on" and forwards the request with no
+    permission check at all, straight to the add-on's own web UI.
+
+    Two near-simultaneous requests were enough to do it, and the cold cache
+    after a restart is exactly when the window is open.
+    """
+    guard = IngressGuard(hass)
+    started = asyncio.Event()
+    finish = asyncio.Event()
+    loads = 0
+
+    async def _slow_load() -> None:
+        nonlocal loads
+        loads += 1
+        started.set()
+        # Stands in for the Supervisor round trip: the whole window is here.
+        await finish.wait()
+        guard._slugs = {"denied-addon": "core_ssh"}
+        guard._loaded_at = time.monotonic()
+
+    guard._async_load = _slow_load
+
+    first = asyncio.create_task(guard.async_slug_for("denied-addon"))
+    await started.wait()
+    second = asyncio.create_task(guard.async_slug_for("denied-addon"))
+    # Let the second request get as far as it is going to before the first
+    # finishes; without the lock this is where it read the stale map.
+    await asyncio.sleep(0)
+    finish.set()
+
+    assert await first == "core_ssh"
+    assert await second == "core_ssh", (
+        "a request arriving during the rebuild was told the add-on does not "
+        "exist, and would have been forwarded unguarded"
+    )
+    assert loads == 1, "and the two of them share one Supervisor rebuild"

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -17,6 +17,7 @@ from typing import Any
 import aiohttp
 import pytest
 from aiohttp import web
+from aiohttp.test_utils import make_mocked_request
 from homeassistant.components.http.auth import async_sign_path
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
@@ -868,3 +869,40 @@ async def test_stopping_the_proxy_closes_its_session(
 
     assert session.closed
     assert proxy._websession is None
+
+
+async def test_a_protocol_relative_path_cannot_redirect_the_upstream(
+    proxy_env: dict[str, Any],
+) -> None:
+    """The proxy must only ever fetch from the host it was configured with.
+
+    `join` resolves its argument the way a browser resolves a link, so a
+    request path beginning with two slashes is a protocol-relative URL naming
+    a host: `//example.com/x` replaced the upstream outright. The proxy then
+    fetched `http://example.com/x` from the Home Assistant machine and relayed
+    the answer -- reaching anything that machine can reach, the rest of the
+    home network and a cloud instance's metadata endpoint included.
+
+    It happens in `_upstream_url`, before any user is resolved, so it needed no
+    login at all. Checked here at the URL rather than by standing up a second
+    server, because the assertion is exactly "the host never changes".
+    """
+    proxy = proxy_env["proxy"]
+    upstream = proxy._base.host
+
+    for target in (
+        "//example.com/x",
+        "///example.com/x",
+        "//example.com:8123/x?a=b",
+        "/api/states",
+        "/api/camera_proxy/camera.front?token=abc&authSig=xyz",
+    ):
+        request = make_mocked_request("GET", target)
+        assert proxy._upstream_url(request).host == upstream, target
+
+    # The path and query still arrive byte for byte, which the signed-path
+    # HMAC depends on: it is computed over the exact path and query.
+    signed = make_mocked_request("GET", "/api/camera_proxy/camera.front?authSig=xyz")
+    assert proxy._upstream_url(signed).raw_path_qs == (
+        "/api/camera_proxy/camera.front?authSig=xyz"
+    )

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -26,7 +26,7 @@ from pytest_homeassistant_custom_component.common import MockUser
 from custom_components.ha_rbac.catalog import Catalog
 from custom_components.ha_rbac.const import ROLE_READ_ONLY, TIER_ADMIN
 from custom_components.ha_rbac.decide import Decider
-from custom_components.ha_rbac.denylog import DenyLog
+from custom_components.ha_rbac.denylog import Denial, DenyLog
 from custom_components.ha_rbac.filters import REGISTRY
 from custom_components.ha_rbac.ingress import SESSION_ENDPOINT
 from custom_components.ha_rbac.policy import Evaluator, Permissions
@@ -868,3 +868,71 @@ async def test_stopping_the_proxy_closes_its_session(
 
     assert session.closed
     assert proxy._websession is None
+
+
+async def test_a_denial_never_reaches_a_restricted_subscriber(
+    proxy_env: dict[str, Any], hass_admin_user: MockUser
+) -> None:
+    """GHSA-h97w-7gj8-g423: the deny log was being broadcast to everyone.
+
+    Every refusal is fired onto Home Assistant's own bus as `rbac_denied`,
+    carrying `detail` -- which names commands, tiers and entity ids, and which
+    `decide.py` documents as a diagnostic that must never reach the person
+    refused -- along with the id and name of whoever was refused. Neither the
+    state-changed filter nor the generic walk touched it: `resources` is not a
+    key either of them recognises, and `detail` is free text.
+
+    The subscriber here is a Home Assistant administrator scoped down by a
+    role, which is the case this whole integration exists for -- and the case
+    that can reach `subscribe_events` with no filter, since Home Assistant
+    refuses that to a genuinely non-admin account. Their role denies every
+    lock, and the denial they must not see is about one.
+    """
+    hass, store = proxy_env["hass"], proxy_env["store"]
+    hass.states.async_set("lock.front", "locked")
+    hass.states.async_set("light.kitchen", "on")
+
+    role = await store.async_create_role(
+        {
+            "name": "Scoped down",
+            "allow": {"entities": {"all": {"read": True}}},
+            "deny": {"entities": {"domains": {"lock": True}}},
+        }
+    )
+    await store.async_set_binding(hass_admin_user.id, [role["id"]])
+
+    async with aiohttp.ClientSession() as session:
+        ws = await _ws_login(session, proxy_env["ws"], proxy_env["admin_token"])
+        await ws.send_json({"id": 1, "type": "subscribe_events"})
+        first = await asyncio.wait_for(ws.receive_json(), timeout=5)
+        assert first["success"], first
+
+        proxy_env["denylog"].async_record(
+            Denial(
+                user_id="someone-else",
+                user_name="Bystander",
+                kind="ws",
+                name="call_service",
+                reason="resource",
+                resources=["lock.front"],
+                detail="no control access to lock.front",
+            )
+        )
+        # Something they may see, fired afterwards: it proves the subscription
+        # is live, so an empty result cannot pass this test by accident.
+        hass.states.async_set("light.kitchen", "off")
+        await hass.async_block_till_done()
+
+        seen = []
+        with contextlib.suppress(TimeoutError):
+            while len(seen) < 8:
+                seen.append(await asyncio.wait_for(ws.receive_json(), timeout=2))
+        await ws.close()
+
+    raw = json.dumps(seen)
+    assert "rbac_denied" not in raw, f"the denial reached a restricted user: {raw}"
+    assert "Bystander" not in raw, "and named who was refused"
+    assert "no control access" not in raw, "and what they were refused"
+    assert any(
+        frame.get("event", {}).get("event_type") == "state_changed" for frame in seen
+    ), "precondition: the subscription really was streaming"

--- a/tests/test_proxy.py
+++ b/tests/test_proxy.py
@@ -17,12 +17,12 @@ from typing import Any
 import aiohttp
 import pytest
 from aiohttp import web
-from aiohttp.test_utils import make_mocked_request
 from homeassistant.components.http.auth import async_sign_path
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 from homeassistant.setup import async_setup_component
 from pytest_homeassistant_custom_component.common import MockUser
+from yarl import URL
 
 from custom_components.ha_rbac.catalog import Catalog
 from custom_components.ha_rbac.const import ROLE_READ_ONLY, TIER_ADMIN
@@ -883,26 +883,38 @@ async def test_a_protocol_relative_path_cannot_redirect_the_upstream(
     the answer -- reaching anything that machine can reach, the rest of the
     home network and a cloud instance's metadata endpoint included.
 
-    It happens in `_upstream_url`, before any user is resolved, so it needed no
-    login at all. Checked here at the URL rather than by standing up a second
-    server, because the assertion is exactly "the host never changes".
+    It happens in `_upstream_url`, before any user is resolved, so it needs no
+    login at all. Driven through a real socket rather than a mocked request,
+    because aiohttp's test helper parses `//example.com/x` into a host and a
+    path of `/x` and so cannot reproduce what the server actually receives.
     """
     proxy = proxy_env["proxy"]
     upstream = proxy._base.host
+    seen: list[str] = []
+    original = proxy._upstream_url
 
-    for target in (
-        "//example.com/x",
-        "///example.com/x",
-        "//example.com:8123/x?a=b",
-        "/api/states",
-        "/api/camera_proxy/camera.front?token=abc&authSig=xyz",
-    ):
-        request = make_mocked_request("GET", target)
-        assert proxy._upstream_url(request).host == upstream, target
+    def _record(request: Any) -> Any:
+        url = original(request)
+        seen.append(str(url))
+        return url
 
-    # The path and query still arrive byte for byte, which the signed-path
-    # HMAC depends on: it is computed over the exact path and query.
-    signed = make_mocked_request("GET", "/api/camera_proxy/camera.front?authSig=xyz")
-    assert proxy._upstream_url(signed).raw_path_qs == (
-        "/api/camera_proxy/camera.front?authSig=xyz"
-    )
+    proxy._upstream_url = _record
+    base = proxy_env["base"].rsplit(":", 1)[0].removeprefix("http://")
+    port = int(proxy_env["base"].rsplit(":", 1)[1])
+
+    for target in ("//example.com/x", "///example.com/x", "//example.com:80/y?a=b"):
+        reader, writer = await asyncio.open_connection(base, port)
+        writer.write(
+            f"GET {target} HTTP/1.1\r\nHost: h\r\nConnection: close\r\n\r\n".encode()
+        )
+        await writer.drain()
+        with contextlib.suppress(TimeoutError, OSError):
+            await asyncio.wait_for(reader.read(64), timeout=3)
+        writer.close()
+        with contextlib.suppress(OSError):
+            await writer.wait_closed()
+
+    proxy._upstream_url = original
+    assert seen, "precondition: the requests reached the proxy"
+    for url in seen:
+        assert URL(url).host == upstream, f"upstream was redirected to {url}"

--- a/tests/test_regressions.py
+++ b/tests/test_regressions.py
@@ -28,7 +28,13 @@ from homeassistant.setup import async_setup_component
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.ha_rbac import async_setup_entry, async_unload_entry
-from custom_components.ha_rbac.catalog import Catalog, build_routes
+from custom_components.ha_rbac.catalog import (
+    Catalog,
+    CommandInfo,
+    RouteInfo,
+    _url_to_pattern,
+    build_routes,
+)
 from custom_components.ha_rbac.const import (
     CONF_BIND_ADDRESS,
     CONF_PROXY_PORT,
@@ -1555,3 +1561,136 @@ async def test_a_rest_body_naming_a_resource_is_not_bound_by_its_service(
     )
     assert decision.allowed is False
     assert decision.reason == REASON_UNBOUNDED
+
+
+async def _camera_decider(hass: HomeAssistant) -> Decider:
+    """Return a decider on an instance with one registered camera."""
+    for domain in ("websocket_api", "config", "api"):
+        await async_setup_component(hass, domain, {})
+    await hass.async_block_till_done()
+    entities = er.async_get(hass)
+    entities.async_get_or_create(
+        "camera", "demo", "bedroom", suggested_object_id="bedroom"
+    )
+    hass.states.async_set("camera.bedroom", "recording")
+    catalog = Catalog(hass)
+    catalog.rebuild()
+    # As Frigate registers them: its own commands, admin-gated by nothing, so
+    # the tier gate lets them through and the resource gate is what must judge.
+    for command in ("frigate/recordings/get", "frigate/events/get"):
+        catalog._commands[command] = CommandInfo(
+            command=command,
+            tier=TIER_OPEN,
+            required_resources=set(),
+            optional_resources=set(),
+            is_write=False,
+        )
+    return Decider(hass, catalog, REGISTRY)
+
+
+def _may_read_all_but(hass: HomeAssistant, denied: str) -> Permissions:
+    """Return permissions reading everything except one entity."""
+    role = compile_role(
+        hass,
+        _role(
+            allow={CAT_ENTITIES: {SUBCAT_ALL: {POLICY_READ: True}}},
+            deny={CAT_ENTITIES: {"entity_ids": {denied: True}}},
+        ),
+        _lookup(hass),
+    )
+    return Permissions(roles=[role])
+
+
+async def test_an_integrations_own_word_for_a_camera_still_names_it(
+    hass: HomeAssistant,
+) -> None:
+    """GHSA-23ch-3r34-x2hq: Frigate asks for a camera without an entity id.
+
+    An integration is free to invent its own vocabulary for something Home
+    Assistant already has an entity for. Frigate's websocket commands take
+    `{"camera": "bedroom"}` and its REST routes put the same name in a path
+    segment, so the resource gate saw a request that named nothing at all and
+    the role's deny rule for `camera.bedroom` was never consulted. The reply is
+    video, which carries no entity data of its own and is therefore streamed
+    rather than filtered, so nothing downstream caught it either.
+
+    Resolved the way every other guess here is: try it, and let the registry
+    decide. A key that is a domain qualifies its value, and `camera.bedroom`
+    counts only because it turns out to be a real entity.
+    """
+    decider = await _camera_decider(hass)
+    permissions = _may_read_all_but(hass, "camera.bedroom")
+
+    named = decider.decide(
+        permissions,
+        KIND_WS,
+        "frigate/recordings/get",
+        {"type": "frigate/recordings/get", "instance_id": "x", "camera": "bedroom"},
+    )
+    assert named.allowed is False, "the camera it asks for is denied"
+    assert named.reason == REASON_RESOURCE
+
+    plural = decider.decide(
+        permissions,
+        KIND_WS,
+        "frigate/events/get",
+        {"type": "frigate/events/get", "cameras": ["bedroom"]},
+    )
+    assert plural.allowed is False, "a list of them is spelled `cameras`"
+
+    # A camera the role may see is unaffected, and so is a value naming nothing.
+    entities = er.async_get(hass)
+    entities.async_get_or_create("camera", "demo", "hall", suggested_object_id="hall")
+    hass.states.async_set("camera.hall", "recording")
+    allowed = decider.decide(
+        permissions,
+        KIND_WS,
+        "frigate/recordings/get",
+        {"type": "frigate/recordings/get", "camera": "hall"},
+    )
+    assert allowed.allowed is True
+
+    unknown = decider.decide(
+        permissions,
+        KIND_WS,
+        "frigate/recordings/get",
+        {"type": "frigate/recordings/get", "camera": "not_a_camera"},
+    )
+    assert unknown.allowed is True, "a name that is no entity binds nothing"
+
+
+async def test_an_integrations_own_route_names_its_camera_too(
+    hass: HomeAssistant,
+) -> None:
+    """The same name, in a path segment instead of a payload.
+
+    `/api/frigate/{instance}/recording/{camera}/start/{s}/end/{e}` names
+    `camera.bedroom` in a segment called `camera`. Only segments named after a
+    Home Assistant resource key were read, so this one was invisible and the
+    request named nothing -- and the reply is `video/mp4`, which is streamed
+    rather than filtered.
+    """
+    decider = await _camera_decider(hass)
+    url = (
+        "/api/frigate/{frigate_instance_id:.+}/recording/{camera:.+}"
+        "/start/{start:[.0-9]+}/end/{end:[.0-9]*}"
+    )
+    decider._catalog._routes = [
+        RouteInfo(
+            pattern=_url_to_pattern(url),
+            url=url,
+            tiers={"get": TIER_OPEN},
+            requires_auth=True,
+        )
+    ]
+
+    decision = decider.decide(
+        _may_read_all_but(hass, "camera.bedroom"),
+        KIND_HTTP,
+        "GET /api/frigate/example/recording/bedroom/start/1/end/2",
+        {},
+    )
+    assert decision.allowed is False
+    assert decision.resources == ["camera.bedroom"], (
+        "the request has to name the camera for the deny rule to be consulted"
+    )

--- a/tests/test_regressions.py
+++ b/tests/test_regressions.py
@@ -1555,3 +1555,116 @@ async def test_a_rest_body_naming_a_resource_is_not_bound_by_its_service(
     )
     assert decision.allowed is False
     assert decision.reason == REASON_UNBOUNDED
+
+
+async def test_a_templated_target_cannot_walk_past_a_deny_rule(
+    hass: HomeAssistant,
+) -> None:
+    """GHSA-r5fr-xh67-8fwc: a one-line Jinja template defeated every denial.
+
+    A resource key was the one place a string reached the buckets without
+    passing the template check the generic walk runs on every other string, so
+    `{"entity_id": "{{ 'lock.gun_safe' }}"}` was recorded as an entity
+    literally called `{{ 'lock.gun_safe' }}`. No deny rule is written against
+    that name, and a blanket `all` allow -- the shape of the built-in User and
+    Editor roles, and of every "allow broadly, deny a few" role -- matched it
+    without ever consulting the deny side. The payload then looked bounded, so
+    it was allowed, and Home Assistant rendered the template server-side and
+    unlocked the entity the role denies.
+
+    Templates are unbounded by the rule that already exists for them. This
+    checks it holds wherever the template is written, including the one place
+    it was not being looked for.
+    """
+    hass.states.async_set("lock.gun_safe", "locked")
+    hass.states.async_set("light.hall", "on")
+    for domain in ("websocket_api", "config", "api"):
+        await async_setup_component(hass, domain, {})
+    await hass.async_block_till_done()
+    catalog = Catalog(hass)
+    catalog.rebuild()
+    decider = Decider(hass, catalog, REGISTRY)
+
+    # Allow everything, deny one thing: what the deny side is for.
+    permissions = Permissions(
+        roles=[
+            compile_role(
+                hass,
+                _role(
+                    allow={
+                        CAT_ENTITIES: {
+                            SUBCAT_ALL: {POLICY_READ: True, POLICY_CONTROL: True}
+                        }
+                    },
+                    deny={CAT_ENTITIES: {"entity_ids": {"lock.gun_safe": True}}},
+                    tiers={"max": TIER_USER, "allow": [], "deny": []},
+                ),
+                _lookup(hass),
+            )
+        ]
+    )
+    assert permissions.check_entity("light.hall", POLICY_CONTROL) is True
+    assert permissions.check_entity("lock.gun_safe", POLICY_CONTROL) is False
+
+    named = decider.decide(
+        permissions,
+        KIND_WS,
+        "call_service",
+        {
+            "type": "call_service",
+            "domain": "lock",
+            "service": "unlock",
+            "target": {"entity_id": "lock.gun_safe"},
+        },
+    )
+    assert named.allowed is False, "precondition: the direct way is refused"
+
+    for payload in (
+        {
+            "type": "execute_script",
+            "sequence": [
+                {
+                    "service": "lock.unlock",
+                    "target": {"entity_id": "{{ 'lock.gun_safe' }}"},
+                }
+            ],
+        },
+        {
+            "type": "call_service",
+            "domain": "lock",
+            "service": "unlock",
+            "target": {"entity_id": "{% if 1 %}lock.gun_safe{% endif %}"},
+        },
+        # A list under the resource key goes the same way, and a real entity
+        # sitting beside the template must not bound the call either.
+        {
+            "type": "call_service",
+            "domain": "lock",
+            "service": "unlock",
+            "target": {"entity_id": ["light.hall", "{{ 'lock.gun_safe' }}"]},
+        },
+    ):
+        decision = decider.decide(permissions, KIND_WS, payload["type"], payload)
+        assert decision.allowed is False, f"allowed: {payload}"
+        # `execute_script` is above this role's tier and is refused there
+        # first; the templated `call_service` reaches the boundedness rule,
+        # which is the gate this is about.
+        assert decision.reason in (REASON_UNBOUNDED, REASON_TIER)
+        assert "{{" not in "".join(decision.resources), (
+            "a template is not an entity id and must not be logged as one"
+        )
+
+    # Without the tier gate in the way, the boundedness rule is what refuses it.
+    templated = decider.decide(
+        permissions,
+        KIND_WS,
+        "call_service",
+        {
+            "type": "call_service",
+            "domain": "lock",
+            "service": "unlock",
+            "target": {"entity_id": "{{ 'lock.gun_safe' }}"},
+        },
+    )
+    assert templated.allowed is False
+    assert templated.reason == REASON_UNBOUNDED


### PR DESCRIPTION
All six open GHSA drafts, each verified by reproducing the reported behaviour first and pinning it with a test that fails without the fix. Plus one more, below, that was sitting in the repo's own CodeQL alerts.

| | Advisory | Fix |
|---|---|---|
| high | **GHSA-r5fr-xh67-8fwc** — templated `entity_id` bypasses every deny rule | A resource key was the one place a string reached the buckets without the template check the generic walk runs on everything else. Confirmed: `call_service` with `target.entity_id: "{{ 'lock.gun_safe' }}"` was **allowed**, with the template text recorded as the entity id. |
| high | **GHSA-rf3j-8w24-5pc8** — inline-gated core views read as open | Confirmed `POST /api/states/{id}` derived `open`, as did `HassIOView` (the Supervisor backup-restore surface) and `DownloadBackupView`. Did **not** flip `derive_tier`'s default as suggested — that reclassifies 56 routes here including `GET /api/states`, which every restricted dashboard reads. Recognises the gate instead: `is_admin` *plus a refusal beside it*. Exactly 4 routes move, all genuinely administrative; no websocket command moves. |
| medium | **GHSA-p5x6-gpc8-rqh6** — ingress reload race | Reproduced: a miss during an in-flight rebuild got `None`, which the proxy reads as "not an add-on" and forwards unguarded. Concurrent misses now share one rebuild under a lock. |
| medium | **GHSA-h97w-7gj8-g423** — `rbac_denied` leaks to any subscriber | Reproduced end to end. Note HA refuses unfiltered `subscribe_events` to a genuinely non-admin account, so the exposed case is an **admin scoped down by a role** — precisely what this integration is for. Dropped in `filter_event`, the choke point every event frame passes through. |
| medium | **GHSA-px8f-g9qh-j6vc** — `prune` misses container keys; history skips targeted attribute rules | Both halves fixed. History threads the entity id from the key so "hide latitude on person.jane" applies; `device_id`/`area_id`/`label_id`/`floor_id` now resolve through the same expansion the request side uses. |
| medium | **GHSA-23ch-3r34-x2hq** — Frigate camera media | A key that is a domain now qualifies its value, registry-confirmed, so `{"camera": "bedroom"}` and `/recording/{camera}/` bind to `camera.bedroom`. Lovelace's scrubber matches the `_entity`/`_entities` suffix rather than a fixed list, covering `camera_entity`. Did **not** adopt the broader "refuse all unfilterable media naming no resource" — `/local` snapshots and `tts_proxy` audio legitimately name nothing. |

## Also found

**Unauthenticated SSRF in `_upstream_url`.** `join` resolves its argument the way a browser resolves a link, so a path beginning with two slashes is a protocol-relative URL naming a host. Reproduced through a running proxy: `GET //example.com/x` produced an upstream request to `http://example.com/x` — server-side request forgery from the Home Assistant machine, reaching the home network and a cloud instance's metadata endpoint, before any user is resolved. This is what the two open `py/full-ssrf` CodeQL alerts were pointing at.

## Disclosure

These branches are public and the commit messages describe each vulnerability. Worth cutting a release promptly, and a private fork would have been the better vehicle — my mistake.

470 tests, ruff clean.