### PR TITLE
Let a role choose only some of a select's options

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ what an LLM can do in your home.
 | **How much** | Look only, or look and touch. |
 | **What stays private** | Hide details: where someone is, a door code, a serial number. |
 | **Where they can go** | Which dashboards, add-ons and screens are in their sidebar. |
+| **Which options** | On a dropdown of people or modes, the ones they may choose. *The kids can announce as themselves, not as you.* |
 | **When** | Days and hours. *A cleaner, weekdays 9 to 5. A babysitter, Friday evenings.* |
 | **What they can change** | Nothing, everything, or one part of the settings: automations, dashboards, helpers, users, backups. |
 

--- a/custom_components/ha_rbac/decide.py
+++ b/custom_components/ha_rbac/decide.py
@@ -148,6 +148,64 @@ USER_MESSAGES = {
 DEFAULT_USER_MESSAGE = "You do not have permission to do that."
 
 
+# Selects, and the services that move them. `select_option` names the option it
+# wants; the cycling four do not name one at all and would walk to any option in
+# the list, which is the same reach by another route.
+SELECT_DOMAINS = frozenset({"input_select", "select"})
+CHOOSE_SERVICE = "select_option"
+CYCLE_SERVICES = frozenset(
+    {"select_next", "select_previous", "select_first", "select_last"}
+)
+# Rewrites the list of options itself, so a rule naming permitted options could
+# be satisfied by first making the forbidden one permitted.
+REWRITE_SERVICE = "set_options"
+
+
+def _select_services(node: Any, depth: int = 0) -> "list[tuple[str, str]]":
+    """Return every (domain, service) on a select that a payload invokes.
+
+    Walked rather than read off the top level, because `execute_script` carries
+    its calls in a sequence and a role allowed to run one could otherwise put
+    the call it wanted inside it.
+    """
+    if depth > MAX_WALK_DEPTH:
+        return [("", "")]
+    found: list[tuple[str, str]] = []
+    if isinstance(node, dict):
+        for key in SERVICE_KEYS:
+            value = node.get(key)
+            if not isinstance(value, str):
+                continue
+            domain, _, service = value.partition(".")
+            if not service:
+                domain, service = str(node.get("domain") or ""), value
+            if domain in SELECT_DOMAINS:
+                found.append((domain, service))
+        for value in node.values():
+            found.extend(_select_services(value, depth + 1))
+    elif isinstance(node, list):
+        for item in node:
+            found.extend(_select_services(item, depth + 1))
+    return found
+
+
+def _requested_options(node: Any, depth: int = 0) -> set[str]:
+    """Return every value a payload offers as the option to select."""
+    if depth > MAX_WALK_DEPTH:
+        return set()
+    found: set[str] = set()
+    if isinstance(node, dict):
+        option = node.get("option")
+        if isinstance(option, str):
+            found.add(option)
+        for value in node.values():
+            found |= _requested_options(value, depth + 1)
+    elif isinstance(node, list):
+        for item in node:
+            found |= _requested_options(item, depth + 1)
+    return found
+
+
 @dataclass(slots=True)
 class Decision:
     """The verdict on one request, and why."""
@@ -419,6 +477,14 @@ class Decider:
                 resources=denied,
             )
 
+        # 3b. Choice gate. A role may be allowed to work a select without
+        #     being allowed to choose every option on it -- "these people may
+        #     put their own name on the announcer, and nobody else's".
+        if (
+            choice_decision := self._decide_choices(permissions, payload, entities)
+        ) is not None:
+            return choice_decision
+
         # 4. Boundedness. A payload that names nothing, or that carries a
         #    template, does not constrain its own command.
         if not is_bounded(found):
@@ -673,6 +739,74 @@ class Decider:
             return None
         entity_id = f"{domain}.{service}"
         return entity_id if self._entity_exists(entity_id) else None
+
+    @callback
+    def _decide_choices(
+        self, permissions: Permissions, payload: dict[str, Any], entities: set[str]
+    ) -> "Decision | None":
+        """Refuse a select the role may work but may not set to this option.
+
+        Entity permission is the wrong granularity for a select whose options
+        are people. Control of `input_select.announcing` is control of every
+        name on it, and a role that may announce for one person should not be
+        able to announce as another. So a rule narrows the options rather than
+        the entity, and the entity grant stays what it was.
+
+        Three ways to reach an option, and all three are judged. `select_option`
+        names the one it wants. The cycling four name none and would walk to any
+        option in the list, so they are refused outright for a covered entity --
+        there is no way to tell where they will land without tracking the
+        entity's current position, and guessing would be guessing in the
+        permissive direction. `set_options` rewrites the list itself, which
+        would let a forbidden option be made permitted first.
+
+        Judged against every covered entity the payload names rather than
+        matching each call to its own target: a payload naming two selects and
+        one option is asking for that option on both as far as anything here
+        can tell, and refusing is the direction to be wrong in.
+        """
+        if not permissions.restricts_options:
+            return None
+        calls = _select_services(payload)
+        if not calls:
+            return None
+
+        covered = {
+            entity_id: allowed
+            for entity_id in entities
+            if (allowed := permissions.options_allowed(entity_id)) is not None
+        }
+        if not covered:
+            return None
+
+        services = {service for _, service in calls}
+        blocked = services & (CYCLE_SERVICES | {REWRITE_SERVICE})
+        if blocked:
+            return Decision(
+                allowed=False,
+                reason=REASON_RESOURCE,
+                detail=(
+                    f"{', '.join(sorted(blocked))} can reach any option on "
+                    f"{', '.join(sorted(covered))}"
+                ),
+                message="You can only choose certain options there.",
+                resources=sorted(covered),
+            )
+
+        if CHOOSE_SERVICE not in services:
+            return None
+
+        permitted = set.intersection(*covered.values()) if covered else set()
+        if refused := sorted(_requested_options(payload) - permitted):
+            return Decision(
+                allowed=False,
+                reason=REASON_RESOURCE,
+                detail=f"option {', '.join(refused)} not permitted on "
+                f"{', '.join(sorted(covered))}",
+                message="You can only choose certain options there.",
+                resources=sorted(covered),
+            )
+        return None
 
     @callback
     def _observe(

--- a/custom_components/ha_rbac/frontend/ha-rbac-panel.js
+++ b/custom_components/ha_rbac/frontend/ha-rbac-panel.js
@@ -317,6 +317,15 @@ function readSchedule(role) {
   return rules;
 }
 
+/** Read a role's choices section into editable rows. */
+function readChoiceRules(role) {
+  return ((role.choices || {}).rules || []).map((rule) => ({
+    target: rule.target || "domains",
+    ids: [...(rule.ids || [])],
+    options: [...(rule.options || [])],
+  }));
+}
+
 /** Read a role's attribute section into editable rows. */
 function readAttributeRules(role) {
   const attributes = role.attributes || {};
@@ -555,6 +564,7 @@ class HaRbacPanel extends HTMLElement {
           tierAllow: [...((role.tiers || {}).allow || [])],
           tierDeny: [...((role.tiers || {}).deny || [])],
           attrRules: readAttributeRules(role),
+          choiceRules: readChoiceRules(role),
         }
       : null;
   }
@@ -749,6 +759,22 @@ class HaRbacPanel extends HTMLElement {
         </div>
       </ha-expansion-panel>
 
+      <ha-expansion-panel data-section="choices" data-title="Choices on a select"
+        header="Choices on a select">
+        <div class="card-content">      <p class="hint">Being allowed to work a
+        dropdown is being allowed to pick anything on it. Where the options are
+        people &mdash; who is announcing, whose room this is &mdash; that is
+        usually too much. Name the options this role may choose and the rest are
+        refused, while the entity itself stays as permitted as you left it
+        above. Comma separated, and matched exactly. Leave a select unnamed here
+        and nothing about it changes.</p>
+      <div id="choice-rules"></div>
+      <div class="actions">
+        <ha-button id="add-choice" ${locked ? "disabled" : ""}>Limit a select</ha-button>
+      </div>
+        </div>
+      </ha-expansion-panel>
+
       <ha-expansion-panel data-section="admin" data-title="Administration: what this role can change"
         header="Administration: what this role can change">
         <div class="card-content">      <p class="hint">Everything in this section is an administrator's job.
@@ -913,6 +939,7 @@ class HaRbacPanel extends HTMLElement {
     this._mountLocation(host.querySelector("#location"), locked);
     this._mountRules(host.querySelector("#rules"), locked);
     this._mountAttrRules(host.querySelector("#attr-rules"), locked);
+    this._mountChoiceRules(host.querySelector("#choice-rules"), locked);
   }
 
   /**
@@ -1148,6 +1175,10 @@ class HaRbacPanel extends HTMLElement {
       case "details": {
         const rules = draft.attrRules.filter((r) => r.names.length).length;
         return rules ? `${rules} rule${rules === 1 ? "" : "s"}` : "Nothing hidden";
+      }
+      case "choices": {
+        const rules = draft.choiceRules.filter((r) => r.options.length).length;
+        return rules ? `${rules} select${rules === 1 ? "" : "s"}` : "Anything on any";
       }
       case "admin": {
         if ((draft.tiers || {}).max === "admin") return "A full administrator";
@@ -1428,6 +1459,59 @@ class HaRbacPanel extends HTMLElement {
     button.disabled = locked;
     button.addEventListener("click", onClick);
     return button;
+  }
+
+  _mountChoiceRules(host, locked) {
+    if (!host) return;
+    host.innerHTML = "";
+    host.appendChild(
+      this._fallbackRow(
+        "Every option",
+        "Free to choose",
+        "Unless a rule below narrows it"
+      )
+    );
+    this._draft.choiceRules.forEach((rule, index) => {
+      host.appendChild(this._choiceRow(rule, index, locked));
+    });
+  }
+
+  _choiceRow(rule, index, locked) {
+    const row = document.createElement("div");
+    row.className = "rule deny";
+
+    const target = this._select(TARGETS, rule.target, locked, "Applies to", (value) => {
+      rule.target = value;
+      rule.ids = [];
+      this._mountChoiceRules(this.shadowRoot.getElementById("choice-rules"), locked);
+    });
+
+    const picker = document.createElement("div");
+    picker.className = "picker";
+    picker.appendChild(this._pickerFor(rule, locked));
+
+    const options = document.createElement("ha-input");
+    options.label = "Options they may choose";
+    options.value = rule.options.join(", ");
+    options.placeholder = "Jan, Nobody";
+    options.disabled = locked;
+    options.addEventListener("change", () => {
+      rule.options = options.value
+        .split(",")
+        .map((n) => n.trim())
+        .filter(Boolean);
+    });
+
+    const remove = this._removeButton(locked, () => {
+      this._draft.choiceRules.splice(index, 1);
+      this._mountChoiceRules(this.shadowRoot.getElementById("choice-rules"), locked);
+    });
+
+    target.classList.add("f-target");
+    options.classList.add("f-detail");
+    remove.classList.add("f-remove");
+    row.append(target, picker, options, remove);
+    return row;
   }
 
   _attrRow(rule, index, locked) {
@@ -1802,6 +1886,10 @@ class HaRbacPanel extends HTMLElement {
       this._draft.schedule.push({ days: [], start: "", end: "" });
       this._mountSchedule(root.getElementById("schedule"), false);
     });
+    on("add-choice", () => {
+      this._draft.choiceRules.push({ target: "entity_ids", ids: [], options: [] });
+      this._mountChoiceRules(root.getElementById("choice-rules"), false);
+    });
     on("add-attr", () => {
       this._draft.attrRules.push({ target: "domains", ids: [], names: [] });
       this._mountAttrRules(root.getElementById("attr-rules"), false);
@@ -1892,6 +1980,17 @@ class HaRbacPanel extends HTMLElement {
             names: rule.names,
           })),
       },
+      choices: {
+        // A rule naming no option would read as "nothing may be chosen", which
+        // the deny side says more clearly, so it is not written at all.
+        rules: this._draft.choiceRules
+          .filter((rule) => rule.options.length)
+          .map((rule) => ({
+            target: rule.target,
+            ids: rule.ids,
+            options: rule.options,
+          })),
+      },
       schedule: {
         // Written as a list, and the older inline window is cleared so a role
         // saved after an upgrade does not carry both shapes at once.
@@ -1976,6 +2075,7 @@ class HaRbacPanel extends HTMLElement {
           capabilities: source.capabilities,
           apps: source.apps,
           attributes: source.attributes,
+          choices: source.choices,
           schedule: source.schedule,
         },
       });

--- a/custom_components/ha_rbac/policy.py
+++ b/custom_components/ha_rbac/policy.py
@@ -139,6 +139,19 @@ ATTRIBUTE_RULE_SCHEMA = vol.Schema(
     }
 )
 
+# One rule: the options a role may choose on the selects it targets. Same
+# targeting vocabulary as an attribute rule, so "every input_select in the
+# hallway" is spelled the way it is everywhere else.
+CHOICE_RULE_SCHEMA = vol.Schema(
+    {
+        vol.Optional("target", default=ENTITY_DOMAINS): str,
+        vol.Optional("ids", default=list): [str],
+        vol.Required("options"): [str],
+    }
+)
+
+CHOICES_SCHEMA = vol.Schema({vol.Optional("rules", default=list): [CHOICE_RULE_SCHEMA]})
+
 ATTRIBUTES_SCHEMA = vol.Schema(
     {
         vol.Optional("rules", default=list): [ATTRIBUTE_RULE_SCHEMA],
@@ -217,6 +230,7 @@ ROLE_SCHEMA = vol.Schema(
         vol.Optional("capabilities", default=list): [str],
         vol.Optional("apps", default=dict): APPS_SCHEMA,
         vol.Optional("attributes", default=dict): ATTRIBUTES_SCHEMA,
+        vol.Optional("choices", default=dict): CHOICES_SCHEMA,
         vol.Optional("schedule", default=dict): SCHEDULE_SCHEMA,
         vol.Optional("location", default=dict): LOCATION_SCHEMA,
     }
@@ -660,6 +674,59 @@ class CompiledAttributeRule:
         return any(fnmatch(name, pattern) for pattern in self.names)
 
 
+@dataclass(slots=True)
+class CompiledChoiceRule:
+    """The options a role may choose on the selects a rule targets."""
+
+    options: set[str]
+    # None means every entity; otherwise the exact set this rule covers.
+    entity_ids: set[str] | None
+    domains: set[str] | None
+
+    def covers(self, entity_id: str) -> bool:
+        """Return True if this rule applies to an entity."""
+        if self.entity_ids is None and self.domains is None:
+            return True
+        if self.domains is not None and entity_id.partition(".")[0] in self.domains:
+            return True
+        return self.entity_ids is not None and entity_id in self.entity_ids
+
+
+def _compile_choice_rules(
+    hass: HomeAssistant, choices: dict[str, Any]
+) -> list[CompiledChoiceRule]:
+    """Turn a role's choices section into matchers.
+
+    Targeted exactly like an attribute rule, and resolved through the same
+    expansion, so an area or a label means here what it means everywhere else.
+    """
+    compiled: list[CompiledChoiceRule] = []
+    for rule in choices.get("rules") or []:
+        options = {str(option) for option in (rule.get("options") or [])}
+        ids = list(rule.get("ids") or [])
+        if not options:
+            # A rule permitting nothing would be a way to deny the entity
+            # outright, which the deny side already does more clearly.
+            continue
+        if not ids:
+            compiled.append(CompiledChoiceRule(options, None, None))
+            continue
+
+        target = rule.get("target") or ENTITY_DOMAINS
+        if target == ENTITY_DOMAINS:
+            compiled.append(CompiledChoiceRule(options, None, {i.lower() for i in ids}))
+            continue
+        if target == ENTITY_ENTITY_IDS:
+            compiled.append(CompiledChoiceRule(options, {i.lower() for i in ids}, None))
+            continue
+
+        policy = desugar(hass, {CAT_ENTITIES: {target: dict.fromkeys(ids, True)}})
+        resolved = set((policy.get(CAT_ENTITIES) or {}).get(ENTITY_ENTITY_IDS) or {})
+        compiled.append(CompiledChoiceRule(options, resolved, None))
+
+    return compiled
+
+
 def _compile_attribute_rules(
     hass: HomeAssistant, attributes: dict[str, Any]
 ) -> list[CompiledAttributeRule]:
@@ -723,6 +790,7 @@ class CompiledRole:
     app_allow: list[str]
     app_deny: list[str]
     attribute_rules: "list[CompiledAttributeRule]"
+    choice_rules: "list[CompiledChoiceRule]"
     schedule: dict[str, Any]
     location: dict[str, Any]
     # url_path -> level, for dashboards this role gets the contents of.
@@ -780,12 +848,14 @@ def compile_role(
     tiers = role.get("tiers") or {}
     apps = role.get("apps") or {}
     attributes = role.get("attributes") or {}
+    choices = role.get("choices") or {}
     tier_max = _tier_ceiling(tiers.get("max"))
     tier_allow = [
         *capability_patterns(role.get("capabilities")),
         *(tiers.get("allow") or []),
     ]
     attribute_rules = _compile_attribute_rules(hass, attributes)
+    choice_rules = _compile_choice_rules(hass, choices)
 
     return CompiledRole(
         role_id=role["id"],
@@ -799,6 +869,7 @@ def compile_role(
         app_allow=list(apps.get("allow") or []),
         app_deny=list(apps.get("deny") or []),
         attribute_rules=attribute_rules,
+        choice_rules=choice_rules,
         schedule=dict(role.get("schedule") or {}),
         location=dict(role.get("location") or {}),
         dashboard_levels={
@@ -880,6 +951,34 @@ class Permissions:
             for role in self.roles
             for rule in role.attribute_rules
         )
+
+    def options_allowed(self, entity_id: str) -> "set[str] | None":
+        """Return the options a role may choose on a select, or None for any.
+
+        None and an empty set mean different things. None is "no rule covers
+        this entity", which leaves it as unrestricted as the rest of the
+        policy makes it. An empty set would be "no option is permitted", which
+        the deny side already says more clearly, so a rule listing nothing is
+        dropped when it is compiled rather than becoming one.
+
+        Roles combine the way they do everywhere else: a user holding two
+        roles may choose what either of them permits.
+        """
+        if self.pass_through:
+            return None
+        allowed: set[str] = set()
+        covered = False
+        for role in self.roles:
+            for rule in role.choice_rules:
+                if rule.covers(entity_id):
+                    covered = True
+                    allowed |= rule.options
+        return allowed if covered else None
+
+    @property
+    def restricts_options(self) -> bool:
+        """Return True if any role narrows what may be chosen on a select."""
+        return not self.pass_through and any(role.choice_rules for role in self.roles)
 
     @property
     def hides_attributes(self) -> bool:

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -195,6 +195,33 @@ permissions are cached on the user *and* on which of their roles are currently
 in force, and a websocket re-resolves them per frame. A connection stays open
 for hours, which is the same span a schedule covers.
 
+## Choices on a select
+
+Entity permission is the wrong granularity for a select whose options are
+people. Control of `input_select.announcing` is control of every name on it, so
+a role that may announce for one person can announce as another. A role can
+therefore narrow the *options* on the selects it names, leaving the entity
+grant alone.
+
+Three ways to reach an option, and the gate judges all three:
+
+- `select_option` names the one it wants, which is checked against the rule.
+- `select_next`, `select_previous`, `select_first` and `select_last` name none.
+  Where they land depends on where the select already is, so there is no way to
+  judge them without tracking its position, and guessing would guess in the
+  permissive direction. They are refused outright on a covered entity.
+- `set_options` rewrites the list itself, which would let a forbidden option be
+  made permitted first. Also refused.
+
+The payload is walked rather than read at the top level, because
+`execute_script` carries its calls in a sequence. A payload naming two covered
+selects and one option is judged as asking for that option on both: matching
+each call to its own target is more precision than the walk has, and refusing
+is the direction to be wrong in.
+
+An entity no rule covers is untouched, and a role with no rules never enters
+the gate.
+
 ## Multiple roles
 
 A user can hold more than one role at once. Each of the user's active roles

--- a/tests/test_frontend.py
+++ b/tests/test_frontend.py
@@ -71,3 +71,23 @@ def test_deleting_a_role_asks_first() -> None:
     body = source[start : source.index('"roles/delete"', start)]
 
     assert "confirm(" in body, "_deleteRole must confirm before it calls the API"
+
+
+def test_every_editable_rule_list_is_read_back_when_a_role_is_saved() -> None:
+    """A section that renders but is never saved looks like it works and does not.
+
+    Each rule list is read out of the role into a draft, rendered, and written
+    back on save. Miss the last step and the panel accepts the edit, redraws it,
+    and drops it -- which for an access-control rule reads as "I restricted
+    that" when nothing was restricted. Pinned as a set so a section added later
+    is caught by the same check.
+    """
+    source = PANEL.read_text()
+    drafts = set(
+        re.findall(r"(\w+): read(?:Attribute|Choice|Schedule)?\w*\(role\)", source)
+    )
+    assert {"attrRules", "choiceRules"} <= drafts, drafts
+
+    saved = source[source.index("_payload()") :]
+    for draft in drafts:
+        assert f"this._draft.{draft}" in saved, f"{draft} is edited but never saved"

--- a/tests/test_policy.py
+++ b/tests/test_policy.py
@@ -21,14 +21,18 @@ from homeassistant.helpers import (
 from homeassistant.helpers import (
     entity_registry as er,
 )
+from homeassistant.setup import async_setup_component
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
+from custom_components.ha_rbac.catalog import Catalog
 from custom_components.ha_rbac.const import (
     ROLE_EDITOR,
     TIER_ADMIN,
     TIER_OPEN,
     TIER_USER,
 )
+from custom_components.ha_rbac.decide import KIND_WS, REASON_RESOURCE, Decider
+from custom_components.ha_rbac.filters import REGISTRY
 from custom_components.ha_rbac.policy import (
     ROLE_SCHEMA,
     Permissions,
@@ -361,3 +365,245 @@ async def test_the_editor_role_stops_short_of_the_house_itself(
         "lovelace/resources/create",
     ):
         assert permissions.tier_allowed(command, TIER_ADMIN) is False, command
+
+
+async def _select_decider(hass: HomeAssistant) -> Decider:
+    """Return a decider on an instance with an input_select of names."""
+    for domain in ("websocket_api", "config", "api"):
+        await async_setup_component(hass, domain, {})
+    await async_setup_component(
+        hass,
+        "input_select",
+        {
+            "input_select": {
+                "announcing": {
+                    "options": ["Jan", "Federico", "Nobody"],
+                    "initial": "Nobody",
+                }
+            }
+        },
+    )
+    await hass.async_block_till_done()
+    catalog = Catalog(hass)
+    catalog.rebuild()
+    return Decider(hass, catalog, REGISTRY)
+
+
+def _may_announce_as(hass: HomeAssistant, *options: str) -> Permissions:
+    """Control of the announcer, narrowed to certain options."""
+    role = compile_role(
+        hass,
+        _role(
+            allow={
+                CAT_ENTITIES: {
+                    "entity_ids": {
+                        "input_select.announcing": {
+                            POLICY_READ: True,
+                            POLICY_CONTROL: True,
+                        }
+                    }
+                }
+            },
+            choices={
+                "rules": [
+                    {
+                        "target": "entity_ids",
+                        "ids": ["input_select.announcing"],
+                        "options": list(options),
+                    }
+                ]
+            },
+            tiers={"max": TIER_USER, "allow": [], "deny": []},
+        ),
+        _lookup(hass),
+    )
+    return Permissions(roles=[role])
+
+
+def _choose(option: str) -> dict[str, Any]:
+    """Return the payload for choosing one option on the announcer."""
+    return {
+        "type": "call_service",
+        "domain": "input_select",
+        "service": "select_option",
+        "target": {"entity_id": "input_select.announcing"},
+        "service_data": {"option": option},
+    }
+
+
+async def test_a_role_may_be_given_only_some_of_a_selects_options(
+    hass: HomeAssistant,
+) -> None:
+    """Entity permission is the wrong granularity for a select full of people.
+
+    Control of the announcer is control of every name on it, so a role that may
+    announce for one person could announce as anybody. The rule narrows the
+    options and leaves the entity grant alone.
+    """
+    decider = await _select_decider(hass)
+    permissions = _may_announce_as(hass, "Jan")
+
+    assert decider.decide(permissions, KIND_WS, "call_service", _choose("Jan")).allowed
+    refused = decider.decide(permissions, KIND_WS, "call_service", _choose("Federico"))
+    assert refused.allowed is False
+    assert refused.reason == REASON_RESOURCE
+    assert refused.message == "You can only choose certain options there."
+    assert "Federico" not in refused.message, "the option is a diagnostic, not a reply"
+
+
+async def test_cycling_a_select_cannot_walk_past_the_rule(hass: HomeAssistant) -> None:
+    """The four that name no option would reach every one of them.
+
+    `select_next` and its siblings do not say where they are going, and where
+    they land depends on where the select already is. There is no way to judge
+    that without tracking its position, and guessing would be guessing in the
+    permissive direction -- so a covered entity refuses them outright. Without
+    this the rule is one extra request to step around.
+    """
+    decider = await _select_decider(hass)
+    permissions = _may_announce_as(hass, "Jan")
+
+    for service in ("select_next", "select_previous", "select_first", "select_last"):
+        decision = decider.decide(
+            permissions,
+            KIND_WS,
+            "call_service",
+            {
+                "type": "call_service",
+                "domain": "input_select",
+                "service": service,
+                "target": {"entity_id": "input_select.announcing"},
+            },
+        )
+        assert decision.allowed is False, service
+
+
+async def test_rewriting_the_options_cannot_widen_the_rule(
+    hass: HomeAssistant,
+) -> None:
+    """`set_options` replaces the list, so a forbidden name could be added."""
+    decider = await _select_decider(hass)
+    decision = decider.decide(
+        _may_announce_as(hass, "Jan"),
+        KIND_WS,
+        "call_service",
+        {
+            "type": "call_service",
+            "domain": "input_select",
+            "service": "set_options",
+            "target": {"entity_id": "input_select.announcing"},
+            "service_data": {"options": ["Jan", "Federico"]},
+        },
+    )
+    assert decision.allowed is False
+
+
+async def test_a_script_cannot_carry_the_forbidden_choice(hass: HomeAssistant) -> None:
+    """`execute_script` holds its calls in a sequence, so the walk goes in."""
+    decider = await _select_decider(hass)
+    decision = decider.decide(
+        _may_announce_as(hass, "Jan"),
+        KIND_WS,
+        "call_service",
+        {
+            "type": "call_service",
+            "domain": "input_select",
+            "service": "select_option",
+            "target": {"entity_id": "input_select.announcing"},
+            "data": {"option": "Federico"},
+        },
+    )
+    assert decision.allowed is False
+
+
+async def test_a_select_no_rule_covers_is_untouched(hass: HomeAssistant) -> None:
+    """A rule narrows the selects it names and nothing else.
+
+    The role controls both selects; only one of them is ruled. The other must
+    behave exactly as it did before choices existed.
+    """
+    decider = await _select_decider(hass)
+    role = compile_role(
+        hass,
+        _role(
+            allow={
+                CAT_ENTITIES: {
+                    "entity_ids": {
+                        "input_select.announcing": {
+                            POLICY_READ: True,
+                            POLICY_CONTROL: True,
+                        },
+                        "input_select.other": {
+                            POLICY_READ: True,
+                            POLICY_CONTROL: True,
+                        },
+                    }
+                }
+            },
+            choices={
+                "rules": [
+                    {
+                        "target": "entity_ids",
+                        "ids": ["input_select.announcing"],
+                        "options": ["Jan"],
+                    }
+                ]
+            },
+            tiers={"max": TIER_USER, "allow": [], "deny": []},
+        ),
+        _lookup(hass),
+    )
+    permissions = Permissions(roles=[role])
+
+    unruled = decider.decide(
+        permissions,
+        KIND_WS,
+        "call_service",
+        {
+            "type": "call_service",
+            "domain": "input_select",
+            "service": "select_option",
+            "target": {"entity_id": "input_select.other"},
+            "service_data": {"option": "anything"},
+        },
+    )
+    assert unruled.allowed is True, "no rule covers it, so nothing is narrowed"
+
+    # And cycling it, which is refused only where a rule applies.
+    cycled = decider.decide(
+        permissions,
+        KIND_WS,
+        "call_service",
+        {
+            "type": "call_service",
+            "domain": "input_select",
+            "service": "select_next",
+            "target": {"entity_id": "input_select.other"},
+        },
+    )
+    assert cycled.allowed is True
+
+    # The ruled one still is.
+    assert not decider.decide(
+        permissions, KIND_WS, "call_service", _choose("Federico")
+    ).allowed
+
+
+async def test_a_role_without_choice_rules_is_unaffected(hass: HomeAssistant) -> None:
+    """The gate must cost nothing for the roles that do not use it."""
+    decider = await _select_decider(hass)
+    role = compile_role(
+        hass,
+        _role(
+            allow={
+                CAT_ENTITIES: {SUBCAT_ALL: {POLICY_READ: True, POLICY_CONTROL: True}}
+            },
+            tiers={"max": TIER_USER, "allow": [], "deny": []},
+        ),
+        _lookup(hass),
+    )
+    permissions = Permissions(roles=[role])
+    assert permissions.restricts_options is False
+    assert decider.decide(
+        permissions, KIND_WS, "call_service", _choose("Federico")
+    ).allowed


### PR DESCRIPTION
Closes #40 — an `input_select` of who is announcing, where each person should be able to pick themselves and nobody else.

Entity permission is the wrong granularity for that. Control of the announcer is control of every name on it, so the only way to express the request today is to withhold the entity, which withholds the feature. A role can now narrow the *options* on the selects it names, and the entity grant stays as it was.

**Three ways to reach an option, and the gate judges all three.** This is the part worth reviewing:

- `select_option` names the one it wants — checked against the rule.
- `select_next` / `select_previous` / `select_first` / `select_last` name none. Where they land depends on where the select already is, so there is no judging them without tracking its position, and guessing would guess permissively. Refused outright on a covered entity — without this the rule is one extra request to step around.
- `set_options` rewrites the option list itself, which would let a forbidden option be made permitted first. Also refused.

The payload is walked rather than read at the top level, because `execute_script` carries its calls in a sequence.

Targeted with the same vocabulary as an attribute rule (`target` + `ids`) and resolved through the same expansion, so an area or label means here what it means everywhere else. An entity no rule covers is untouched, and a role with no rules never enters the gate — pinned by its own test.

Panel gets its own **Choices on a select** section following the attribute-rule pattern, plus a static check that every editable rule list is actually read back on save: a section that renders but is never saved reads as "I restricted that" when nothing was restricted.

477 tests, ruff clean, README and DESIGN.md updated.